### PR TITLE
Adds cookie filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run unit tests
-        run: go test -count=1 -v -race -cover ./...
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,13 @@ VERSION ?= dev
 GIT_HASH ?=$(shell git rev-parse HEAD)
 IMAGE_NAME := "hypertrace/collector"
 
+.PHONY: unit-test
+unit-test:
+	go test -count=1 -v -race -cover ./...
+
+.PHONY: test
+test: unit-test
+
 .PHONY: build
 build:
 	go build -ldflags "-w -X main.GitHash=${GIT_HASH} -X main.Version=${VERSION}" ./cmd/collector

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module github.com/hypertrace/collector
 
 go 1.15
 
-require go.opentelemetry.io/collector v0.14.0
+require (
+	github.com/stretchr/testify v1.6.1
+	go.opentelemetry.io/collector v0.14.0
+	go.uber.org/zap v1.16.0
+)

--- a/processors/piifilterprocessor/config.go
+++ b/processors/piifilterprocessor/config.go
@@ -1,0 +1,35 @@
+package piifilterprocessor
+
+import (
+	"github.com/hypertrace/collector/processors/piifilterprocessor/filters"
+	"go.opentelemetry.io/collector/config/configmodels"
+)
+
+type Config struct {
+	configmodels.ProcessorSettings `mapstructure:",squash"`
+
+	// Global redaction strategy. Defaults to Redact
+	RedactStrategy filters.RedactionStrategy `mapstructure:"redaction-strategy"`
+
+	// Prefixes attribute name prefix to match the keyword against
+	Prefixes []string `mapstructure:"prefixes"`
+
+	// Regexs are the attribute name of which the value will be filtered
+	// when the regex matches the name
+	KeyRegExs []PiiElement `mapstructure:"key-regexs"`
+
+	// Regexs are the attribute value which will be filtered when
+	// the regex matches
+	ValueRegExs []PiiElement `mapstructure:"value-regexs"`
+}
+
+// PiiElement identifies configuration for PII filtering
+type PiiElement struct {
+	Regex             string                    `mapstructure:"regex"`
+	Category          string                    `mapstructure:"category"`
+	RedactStrategy    filters.RedactionStrategy `mapstructure:"redaction-strategy"`
+	Fqn               *bool                     `mapstructure:"fqn,omitempty"`
+	SessionIdentifier bool                      `mapstructure:"session-identifier"`
+	SessionIndexes    []int                     `mapstructure:"session-indexes"`
+	SessionSeparator  string                    `mapstructure:"session-separator"`
+}

--- a/processors/piifilterprocessor/config_test.go
+++ b/processors/piifilterprocessor/config_test.go
@@ -1,0 +1,22 @@
+package piifilterprocessor
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configtest"
+)
+
+func TestLoadConfig(t *testing.T) {
+	factories, err := componenttest.ExampleComponents()
+	assert.NoError(t, err)
+
+	factories.Processors[typeStr] = NewFactory()
+
+	cfg, err := configtest.LoadConfigFile(t, path.Join(".", "testdata", "config.yml"), factories)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+}

--- a/processors/piifilterprocessor/factory.go
+++ b/processors/piifilterprocessor/factory.go
@@ -1,0 +1,47 @@
+package piifilterprocessor
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/processor/processorhelper"
+)
+
+const (
+	typeStr = "hypertrace_piifilter"
+)
+
+// NewFactory creates a factory for the routing processor.
+func NewFactory() component.ProcessorFactory {
+	return processorhelper.NewFactory(
+		typeStr,
+		createDefaultConfig,
+		processorhelper.WithTraces(createTraceProcessor),
+	)
+}
+
+func createDefaultConfig() configmodels.Processor {
+	return &Config{
+		ProcessorSettings: configmodels.ProcessorSettings{
+			TypeVal: typeStr,
+			NameVal: typeStr,
+		},
+	}
+}
+
+var processorCapabilities = component.ProcessorCapabilities{MutatesConsumedData: true}
+
+func createTraceProcessor(
+	_ context.Context,
+	params component.ProcessorCreateParams,
+	cfg configmodels.Processor,
+	nextConsumer consumer.TracesConsumer,
+) (component.TracesProcessor, error) {
+	return processorhelper.NewTraceProcessor(
+		cfg,
+		nextConsumer,
+		newPIIFilterProcessor(params.Logger, nextConsumer),
+		processorhelper.WithCapabilities(processorCapabilities))
+}

--- a/processors/piifilterprocessor/filters/cookie/filter.go
+++ b/processors/piifilterprocessor/filters/cookie/filter.go
@@ -1,0 +1,69 @@
+package cookie
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/hypertrace/collector/processors/piifilterprocessor/filters"
+	"github.com/hypertrace/collector/processors/piifilterprocessor/filters/internal/matcher"
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+var _ filters.Filter = (*cookieFilter)(nil)
+
+type cookieFilter struct {
+	m  matcher.Matcher
+	rs filters.RedactionStrategy
+}
+
+func (f *cookieFilter) RedactAttribute(key string, value pdata.AttributeValue) (bool, error) {
+	if len(value.StringVal()) == 0 {
+		return false, nil
+	}
+
+	cookies := parseCookies(key, value.StringVal())
+	if cookies == nil {
+		return false, nil
+	}
+
+	isRedacted := false
+	for _, cookie := range cookies {
+		if isRedactedByKey, redactedValue := f.m.FilterKeyRegexs(cookie.Name, key, cookie.Value, cookie.Name); isRedactedByKey {
+			cookie.Value = redactedValue
+			isRedacted = true
+		} else if isRedactedByValue, redactedValue := f.m.FilterStringValueRegexs(cookie.Value, key, cookie.Name); isRedactedByValue {
+			cookie.Value = redactedValue
+			isRedacted = true
+		}
+	}
+
+	if isRedacted {
+		value.SetStringVal(stitchCookies(cookies))
+	}
+
+	return isRedacted, nil
+}
+
+func parseCookies(key string, value string) []*http.Cookie {
+	unindexedKey := strings.Split(key, "[")[0]
+	switch unindexedKey {
+	case "http.request.header.cookie":
+		header := http.Header{"Cookie": {value}}
+		request := http.Request{Header: header}
+		return request.Cookies()
+
+	case "http.response.header.set-cookie":
+		header := http.Header{"Set-Cookie": {value}}
+		response := http.Response{Header: header}
+		return response.Cookies()
+	}
+	return nil
+}
+
+func stitchCookies(cookies []*http.Cookie) string {
+	cookieStrSlice := make([]string, len(cookies))
+	for idx, cookie := range cookies {
+		cookieStrSlice[idx] = cookie.String()
+	}
+	return strings.Join(cookieStrSlice, "; ")
+}

--- a/processors/piifilterprocessor/filters/cookie/filter_test.go
+++ b/processors/piifilterprocessor/filters/cookie/filter_test.go
@@ -1,0 +1,61 @@
+package cookie
+
+import (
+	"testing"
+
+	"github.com/hypertrace/collector/processors/piifilterprocessor/filters"
+	"github.com/hypertrace/collector/processors/piifilterprocessor/filters/internal/matcher"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func Test_piifilterprocessor_cookie_FilterKey(t *testing.T) {
+	key := "http.request.header.cookie"
+	cookieValue := "cookie1=value1"
+	expectedCookieFilteredValue := "cookie1=value1"
+
+	filter := newCookieFilter(t)
+
+	attrValue := pdata.NewAttributeValueString(cookieValue)
+	isRedacted, err := filter.RedactAttribute(key, attrValue)
+	assert.NoError(t, err)
+	assert.False(t, isRedacted)
+	assert.Equal(t, expectedCookieFilteredValue, attrValue.StringVal())
+}
+
+func TestCookieFilterFiltersCookieKey(t *testing.T) {
+	key := "http.request.header.cookie"
+	cookieValue := "cookie1=value1; password=value2"
+	expectedCookieFilteredValue := "cookie1=value1; password=***"
+	filter := newCookieFilter(t)
+
+	attrValue := pdata.NewAttributeValueString(cookieValue)
+	isRedacted, err := filter.RedactAttribute(key, attrValue)
+	assert.NoError(t, err)
+	assert.True(t, isRedacted)
+	assert.Equal(t, expectedCookieFilteredValue, attrValue.StringVal())
+}
+
+func TestCookieFilterFiltersSetCookieKey(t *testing.T) {
+	key := "http.response.header.set-cookie"
+	cookieValue := "password=value2; SameSite=Strict"
+	expectedCookieFilteredValue := "password=***; SameSite=Strict"
+	filter := newCookieFilter(t)
+
+	attrValue := pdata.NewAttributeValueString(cookieValue)
+	isRedacted, err := filter.RedactAttribute(key, attrValue)
+	assert.NoError(t, err)
+	assert.True(t, isRedacted)
+	assert.Equal(t, expectedCookieFilteredValue, attrValue.StringVal())
+}
+
+func newCookieFilter(t *testing.T) *cookieFilter {
+	m, err := matcher.NewRegexMatcher([]matcher.Regex{{
+		Pattern: "^password$",
+	}}, []matcher.Regex{}, filters.Redact)
+	if err != nil {
+		t.Fatalf("failed to create cookie filter: %v\n", err)
+	}
+
+	return &cookieFilter{m: m}
+}

--- a/processors/piifilterprocessor/filters/filter.go
+++ b/processors/piifilterprocessor/filters/filter.go
@@ -1,0 +1,11 @@
+package filters
+
+import "go.opentelemetry.io/collector/consumer/pdata"
+
+// Filter redacts attributes from a span
+type Filter interface {
+	// RedactAttribute decided to redact and attribute and returns true if the value has
+	// been redacted or false otherwise. It also returns and error when something went
+	// went wrong by redacting the value.
+	RedactAttribute(key string, value pdata.AttributeValue) (isRedacted bool, err error)
+}

--- a/processors/piifilterprocessor/filters/internal/matcher/matcher.go
+++ b/processors/piifilterprocessor/filters/internal/matcher/matcher.go
@@ -1,0 +1,10 @@
+package matcher
+
+// Matcher allows to match and filter regexs in key and string values for attributes.
+type Matcher interface {
+	// Looks into the key to decide whether filter the value or not
+	FilterKeyRegexs(keyToMatch string, actualKey string, value string, path string) (isRedacted bool, redactedValue string)
+
+	// Looks into the string value to decide whether filter the value or not
+	FilterStringValueRegexs(value string, key string, path string) (isRedacted bool, redactedValue string)
+}

--- a/processors/piifilterprocessor/filters/internal/matcher/regex.go
+++ b/processors/piifilterprocessor/filters/internal/matcher/regex.go
@@ -1,0 +1,178 @@
+package matcher
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hypertrace/collector/processors/piifilterprocessor/filters"
+)
+
+type Regex struct {
+	Pattern        string
+	RedactStrategy filters.RedactionStrategy
+}
+
+type CompiledRegex struct {
+	*regexp.Regexp
+	Regex
+}
+
+var _ Matcher = (*regexMatcher)(nil)
+
+type regexMatcher struct {
+	hash        func(string) string
+	keyRegexs   []CompiledRegex
+	valueRegexs []CompiledRegex
+}
+
+func NewRegexMatcher(
+	keyRegexs,
+	valueRegexs []Regex,
+	globalStrategy filters.RedactionStrategy,
+) (*regexMatcher, error) {
+	compiledKeyRegexs, err := compileRegexs(keyRegexs, globalStrategy)
+	if err != nil {
+		return nil, err
+	}
+
+	compiledValueRegexs, err := compileRegexs(valueRegexs, globalStrategy)
+	if err != nil {
+		return nil, err
+	}
+
+	return &regexMatcher{
+		keyRegexs:   compiledKeyRegexs,
+		valueRegexs: compiledValueRegexs,
+	}, nil
+}
+
+func (pfp *regexMatcher) FilterKeyRegexs(keyToMatch string, actualKey string, value string, path string) (bool, string) {
+	for _, r := range pfp.keyRegexs {
+		if r.Regexp.MatchString(keyToMatch) {
+			return pfp.FilterMatchedKey(r.RedactStrategy, actualKey, value, path)
+		}
+	}
+
+	return false, ""
+}
+
+func (pfp *regexMatcher) FilterStringValueRegexs(value string, key string, path string) (bool, string) {
+	inspectorKey := getFullyQualifiedInspectorKey(key, path)
+
+	filtered := false
+	for _, r := range pfp.valueRegexs {
+		filtered, value = pfp.replacingRegex(value, inspectorKey, r.Regexp, r.RedactStrategy)
+	}
+
+	return filtered, value
+}
+
+func (pfp *regexMatcher) replacingRegex(value string, key string, regex *regexp.Regexp, rs filters.RedactionStrategy) (bool, string) {
+	matchCount := 0
+
+	filtered := regex.ReplaceAllStringFunc(value, func(src string) string {
+		matchCount++
+		_, str := pfp.redactAndFilterData(rs, src, key)
+		return str
+	})
+
+	return matchCount > 0, filtered
+}
+
+func unindexedKey(key string) string {
+	if len(key) == 0 {
+		return ""
+	}
+	return strings.Split(key, "[")[0]
+}
+
+const (
+	queryParamTag     = "http.request.query.param"
+	requestCookieTag  = "http.request.cookie"
+	responseCookieTag = "http.response.cookie"
+	sessionIDTag      = "session.id"
+	// In case of empty json path, platform uses strings defined here as path
+	requestBodyEmptyJsonPath  = "REQUEST_BODY"
+	responseBodyEmptyJsonPath = "RESPONSE_BODY"
+)
+
+func mapRawToEnriched(rawTag string, path string) (string, string) {
+	enrichedTag := rawTag
+	enrichedPath := path
+
+	unindexedKey := unindexedKey(rawTag)
+	switch unindexedKey {
+	case "http.url":
+		enrichedTag = queryParamTag
+	case "http.request.header.cookie":
+		enrichedTag = requestCookieTag
+	case "http.response.header.set-cookie":
+		enrichedTag = responseCookieTag
+	case "http.request.body":
+		if len(path) == 0 {
+			enrichedPath = requestBodyEmptyJsonPath
+		}
+	case "http.response.body":
+		if len(path) == 0 {
+			enrichedPath = responseBodyEmptyJsonPath
+		}
+	}
+
+	return enrichedTag, enrichedPath
+}
+
+func getFullyQualifiedInspectorKey(actualKey string, path string) string {
+	inspectorKey, enrichedPath := mapRawToEnriched(actualKey, path)
+
+	if len(enrichedPath) > 0 {
+		inspectorKey = fmt.Sprintf("%s.%s", inspectorKey, enrichedPath)
+	}
+
+	return inspectorKey
+}
+
+func (pfp *regexMatcher) redactAndFilterData(redact filters.RedactionStrategy, value string, inspectorKey string) (bool, string) {
+	var redacted string
+	var isModified = true
+	switch redact {
+	case filters.Redact:
+		redacted = filters.RedactedText
+	case filters.Hash:
+		redacted = pfp.hash(value)
+	case filters.Raw:
+		redacted = value
+	default:
+		redacted = filters.RedactedText
+	}
+
+	return isModified, redacted
+}
+
+func (pfp *regexMatcher) FilterMatchedKey(redactionStrategy filters.RedactionStrategy, actualKey string, value string, path string) (bool, string) {
+	inspectorKey := getFullyQualifiedInspectorKey(actualKey, path)
+
+	isModified, redacted := pfp.redactAndFilterData(redactionStrategy, value, inspectorKey)
+	return isModified, redacted
+}
+
+func compileRegexs(regexs []Regex, defaultStrategy filters.RedactionStrategy) ([]CompiledRegex, error) {
+	compiledRegexs := make([]CompiledRegex, len(regexs))
+	for i, r := range regexs {
+		cr, err := regexp.Compile(r.Pattern)
+		if err != nil {
+			return nil, fmt.Errorf("error compiling key regex %s already specified", r.Pattern)
+		}
+
+		if r.RedactStrategy == filters.Unknown {
+			r.RedactStrategy = defaultStrategy
+		}
+
+		compiledRegexs[i] = CompiledRegex{
+			Regex:  r,
+			Regexp: cr,
+		}
+	}
+
+	return compiledRegexs, nil
+}

--- a/processors/piifilterprocessor/filters/internal/matcher/regex.go
+++ b/processors/piifilterprocessor/filters/internal/matcher/regex.go
@@ -147,7 +147,7 @@ func (pfp *regexMatcher) redactAndFilterData(redact filters.RedactionStrategy, v
 		redactedValue = filters.RedactedText
 	}
 
-	return isModified, redacted
+	return isModified, redactedValue
 }
 
 func (pfp *regexMatcher) FilterMatchedKey(redactionStrategy filters.RedactionStrategy, actualKey string, value string, path string) (bool, string) {

--- a/processors/piifilterprocessor/filters/internal/matcher/regex.go
+++ b/processors/piifilterprocessor/filters/internal/matcher/regex.go
@@ -93,8 +93,8 @@ const (
 	responseCookieTag = "http.response.cookie"
 	sessionIDTag      = "session.id"
 	// In case of empty json path, platform uses strings defined here as path
-	requestBodyEmptyJsonPath  = "REQUEST_BODY"
-	responseBodyEmptyJsonPath = "RESPONSE_BODY"
+	requestBodyEmptyJSONPath  = "REQUEST_BODY"
+	responseBodyEmptyJSONPath = "RESPONSE_BODY"
 )
 
 func mapRawToEnriched(rawTag string, path string) (string, string) {
@@ -111,11 +111,11 @@ func mapRawToEnriched(rawTag string, path string) (string, string) {
 		enrichedTag = responseCookieTag
 	case "http.request.body":
 		if len(path) == 0 {
-			enrichedPath = requestBodyEmptyJsonPath
+			enrichedPath = requestBodyEmptyJSONPath
 		}
 	case "http.response.body":
 		if len(path) == 0 {
-			enrichedPath = responseBodyEmptyJsonPath
+			enrichedPath = responseBodyEmptyJSONPath
 		}
 	}
 
@@ -133,17 +133,18 @@ func getFullyQualifiedInspectorKey(actualKey string, path string) string {
 }
 
 func (pfp *regexMatcher) redactAndFilterData(redact filters.RedactionStrategy, value string, inspectorKey string) (bool, string) {
-	var redacted string
+	var redactedValue string
 	var isModified = true
 	switch redact {
 	case filters.Redact:
-		redacted = filters.RedactedText
+		redactedValue = filters.RedactedText
 	case filters.Hash:
-		redacted = pfp.hash(value)
+		redactedValue = pfp.hash(value)
 	case filters.Raw:
-		redacted = value
+		redactedValue = value
+		// should we return turn isModified = false here?
 	default:
-		redacted = filters.RedactedText
+		redactedValue = filters.RedactedText
 	}
 
 	return isModified, redacted

--- a/processors/piifilterprocessor/filters/internal/matcher/regex_test.go
+++ b/processors/piifilterprocessor/filters/internal/matcher/regex_test.go
@@ -1,0 +1,42 @@
+package matcher
+
+import (
+	"testing"
+
+	"github.com/hypertrace/collector/processors/piifilterprocessor/filters"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompileRegexs(t *testing.T) {
+	keyRegexes := []Regex{
+		{
+			Pattern: "^a$",
+		},
+		{
+			Pattern:        "^b$",
+			RedactStrategy: filters.Redact,
+		},
+		{
+			Pattern:        "^c$",
+			RedactStrategy: filters.Hash,
+		},
+	}
+
+	compiledRegexes, err := compileRegexs(keyRegexes, filters.Redact)
+	assert.NoError(t, err)
+
+	for _, cr := range compiledRegexes {
+		if cr.Regexp.String() == "^a$" || cr.Regexp.String() == "^b$" {
+			assert.Equal(t, filters.Redact, cr.RedactStrategy)
+		} else {
+			assert.Equal(t, filters.Hash, cr.RedactStrategy)
+		}
+	}
+}
+
+func TestFilterMatchedKey(t *testing.T) {
+	m, _ := NewRegexMatcher([]Regex{{Pattern: "^password$"}}, nil, filters.Redact)
+	isModified, redacted := m.FilterMatchedKey(filters.Redact, "http.request.header.password", "abc123", "")
+	assert.True(t, isModified)
+	assert.Equal(t, "***", redacted)
+}

--- a/processors/piifilterprocessor/filters/strategy.go
+++ b/processors/piifilterprocessor/filters/strategy.go
@@ -1,0 +1,16 @@
+package filters
+
+// RedactionStrategy describes the redaction strategy to use during the filtering
+// of attributes.
+type RedactionStrategy int
+
+const (
+	Unknown RedactionStrategy = iota
+	Redact
+	Hash
+	Raw
+)
+
+const (
+	RedactedText = "***"
+)

--- a/processors/piifilterprocessor/processor.go
+++ b/processors/piifilterprocessor/processor.go
@@ -1,0 +1,62 @@
+package piifilterprocessor
+
+import (
+	"context"
+
+	"github.com/hypertrace/collector/processors/piifilterprocessor/filters"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/processor/processorhelper"
+	"go.uber.org/zap"
+)
+
+var _ processorhelper.TProcessor = (*piiFilterProcessor)(nil)
+
+type piiFilterProcessor struct {
+	next    consumer.TracesConsumer
+	logger  *zap.Logger
+	filters []filters.Filter
+}
+
+func newPIIFilterProcessor(logger *zap.Logger, next consumer.TracesConsumer) *piiFilterProcessor {
+	return &piiFilterProcessor{
+		next:   next,
+		logger: logger,
+	}
+}
+
+func (p *piiFilterProcessor) ProcessTraces(ctx context.Context, td pdata.Traces) (pdata.Traces, error) {
+	rss := td.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		rs := rss.At(i)
+		if rs.IsNil() {
+			continue
+		}
+
+		ilss := rs.InstrumentationLibrarySpans()
+		for j := 0; j < ilss.Len(); j++ {
+			ils := ilss.At(j)
+			if ils.IsNil() {
+				continue
+			}
+			spans := ils.Spans()
+			for k := 0; k < spans.Len(); k++ {
+				span := spans.At(k)
+				if span.IsNil() {
+					// Do not create empty spans just to add attributes
+					continue
+				}
+
+				span.Attributes().ForEach(func(key string, value pdata.AttributeValue) {
+					for _, filter := range p.filters {
+						if _, err := filter.RedactAttribute(key, value); err != nil {
+							p.logger.Sugar().Errorf("failed to filter attributes: %v", err)
+						}
+					}
+				})
+			}
+		}
+	}
+
+	return td, nil
+}

--- a/processors/piifilterprocessor/testdata/config.yml
+++ b/processors/piifilterprocessor/testdata/config.yml
@@ -1,0 +1,13 @@
+receivers:
+  examplereceiver:
+
+processors:
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    traces:
+      receivers: [examplereceiver]
+      exporters: [exampleexporter]


### PR DESCRIPTION
This PR adds a PII filter to the collector to be able to redact the cookies value on string attributes. This code is a copy with some adaptions from old traceable collector (based on OpenCensus) so don't expect everything to make sense from the beginning (specially when it comes to the regex matcher).

I tried to add as much comments as possible to the code but some are yet to be understanded.

Ping @davexroth