### PR TITLE
Uses distroless base image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,12 @@ jobs:
         uses: actions/checkout@v2
       - name: Run unit tests
         run: make test
-      - name: Build and package docker image
-        run: make package
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          tags: hypertrace/collector:latest
+          build-args: |
+            VERSION=latest
+            GIT_COMMIT=${GITHUB_SHA}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Run unit tests
         run: make test
-      - name: Build and push
+      - name: Build collector
+        run: make build
+      - name: Build and push image
         if: matrix.os == 'ubuntu-latest'
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,5 @@ jobs:
         uses: actions/checkout@v2
       - name: Run unit tests
         run: make test
+      - name: Build and package docker image
+        run: make package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Run unit tests
         run: make test
       - name: Build and push
+        if: matrix.os == 'ubuntu-latest'
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ RUN GOOS=linux make build
 
 FROM gcr.io/distroless/base
 # Following folder conventions described in https://unix.stackexchange.com/a/11552
-#RUN apk --update add ca-certificates
-#RUN ["mkdir", "-p", "/usr/local/bin/hypertrace"]
 WORKDIR /usr/local/bin/hypertrace
 
 COPY --from=build-stage /go/src/github.com/hypertrace/collector/collector .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM golang:1.15-alpine AS build-stage
+FROM golang:1.15-buster as build-stage
 
-RUN apk add --update make
 RUN mkdir -p /go/src/github.com/hypertrace/collector
 WORKDIR /go/src/github.com/hypertrace/collector
 
@@ -9,12 +8,12 @@ COPY . /go/src/github.com/hypertrace/collector
 ARG GIT_COMMIT
 ARG VERSION
 
-RUN make build
+RUN GOOS=linux make build
 
-FROM alpine
+FROM gcr.io/distroless/base
 # Following folder conventions described in https://unix.stackexchange.com/a/11552
-RUN apk --update add ca-certificates
-RUN mkdir /usr/local/bin/hypertrace
+#RUN apk --update add ca-certificates
+#RUN ["mkdir", "-p", "/usr/local/bin/hypertrace"]
 WORKDIR /usr/local/bin/hypertrace
 
 COPY --from=build-stage /go/src/github.com/hypertrace/collector/collector .
@@ -22,4 +21,4 @@ COPY default-config.yml /etc/opt/hypertrace/config.yml
 
 EXPOSE 9411
 
-ENTRYPOINT ./collector --config /etc/opt/hypertrace/config.yml
+ENTRYPOINT ["/usr/local/bin/hypertrace/collector", "--config", "/etc/opt/hypertrace/config.yml"]

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test: unit-test
 
 .PHONY: build
 build:
-	go build -ldflags "-w -X main.GitHash=${GIT_HASH} -X main.Version=${VERSION}" ./cmd/collector
+	$(if $(GOOS),GOOS=${GOOS},) go build -ldflags "-w -X main.GitHash=${GIT_HASH} -X main.Version=${VERSION}" ./cmd/collector
 
 .PHONY: run
 run:
@@ -19,7 +19,7 @@ run:
 
 .PHONY: package
 package:
-	docker build --build-arg VERSION=${VERSION} --build-arg GIT_COMMIT=$(GIT_COMMIT) -t $(IMAGE_NAME):${VERSION} -t $(IMAGE_NAME):latest .
+	@docker build --build-arg VERSION=${VERSION} --build-arg GIT_COMMIT=$(GIT_COMMIT) -t $(IMAGE_NAME):${VERSION} .
 
 .PHONY: lint
 lint:

--- a/default-config.yml
+++ b/default-config.yml
@@ -1,3 +1,6 @@
+# This is the default config that is being provided along with the collector
+# image.
+
 extensions:
   health_check:
   pprof:


### PR DESCRIPTION
This PR changes the base image into distroless as there are debuggability and security concerns over alpine.

Ping @davexroth (do you mind dropping here some info about the need for this change?)