### PR TITLE
chore(pii): removes PII next consumer from processor constructor.

### DIFF
--- a/processors/piifilterprocessor/factory.go
+++ b/processors/piifilterprocessor/factory.go
@@ -42,7 +42,7 @@ func createTraceProcessor(
 ) (component.TracesProcessor, error) {
 	piiCfg := cfg.(*Config)
 
-	proc, err := newPIIFilterProcessor(params.Logger, nextConsumer, piiCfg)
+	proc, err := newPIIFilterProcessor(params.Logger, piiCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the PII trace processor: %v", err)
 	}

--- a/processors/piifilterprocessor/processor.go
+++ b/processors/piifilterprocessor/processor.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hypertrace/collector/processors/piifilterprocessor/filters/json"
 	"github.com/hypertrace/collector/processors/piifilterprocessor/filters/regexmatcher"
 	"github.com/hypertrace/collector/processors/piifilterprocessor/filters/urlencoded"
-	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/processor/processorhelper"
 	"go.uber.org/zap"
@@ -19,7 +18,6 @@ import (
 var _ processorhelper.TProcessor = (*piiFilterProcessor)(nil)
 
 type piiFilterProcessor struct {
-	next    consumer.TracesConsumer
 	logger  *zap.Logger
 	filters []filters.Filter
 }
@@ -40,7 +38,6 @@ func toRegex(es []PiiElement) []regexmatcher.Regex {
 
 func newPIIFilterProcessor(
 	logger *zap.Logger,
-	next consumer.TracesConsumer,
 	cfg *Config,
 ) (*piiFilterProcessor, error) {
 	matcher, err := regexmatcher.NewMatcher(
@@ -59,7 +56,6 @@ func newPIIFilterProcessor(
 	}
 
 	return &piiFilterProcessor{
-		next:    next,
 		logger:  logger,
 		filters: fs,
 	}, nil


### PR DESCRIPTION
This PR removes the dependency to the next consumer as we don't use it in the PII processor.

Ping @mohit-a21 