### PR TITLE
chore(config): improves the config so input data is decoupled from domain config.

### DIFF
--- a/_tests/e2e/Makefile
+++ b/_tests/e2e/Makefile
@@ -1,15 +1,15 @@
 run-collector:
-	rm $(PWD)/exported-trace.json || true
-	touch $(PWD)/exported-trace.json
+	@rm $(PWD)/exported-trace.json || true
+	@touch $(PWD)/exported-trace.json
 	go run ../../cmd/collector/* --config ./test-config.yml
 
 run-docker-collector:
-	rm $(PWD)/exported-trace.json || true
-	touch $(PWD)/exported-trace.json
+	@rm $(PWD)/exported-trace.json || true
+	@touch $(PWD)/exported-trace.json
 	docker run -p 9411:9411 \
 	-v $(pwd)/test-config.yml:/etc/opt/hypertrace/config.yml \
 	-v $(pwd)/exported-trace.json:/usr/local/bin/hypertrace/exported-trace.json \
 	hypertrace/hypertrace-collector:dev
 
 test:
-	./test.sh
+	@./test.sh

--- a/_tests/e2e/ingestion-trace.json
+++ b/_tests/e2e/ingestion-trace.json
@@ -15,6 +15,7 @@
             "http.flavor": "1.1",
             "http.host": "backend:9000",
             "http.method": "GET",
+            "card.last_4": "1234",
             "http.request.body": "{\"name\":\"Dave\"}",
             "http.request.header.Content-Type": "application/json",
             "http.request.header.Traceparent": "00-cb5a198128c2f36138d3d48c4b72cd0e-a0ddc4b62d6da703-01",

--- a/_tests/e2e/test-config.yml
+++ b/_tests/e2e/test-config.yml
@@ -3,6 +3,9 @@ receivers:
 
 processors:
   hypertrace_piifilter:
+    redaction_strategy: redact
+    key_regexs:
+      - regex: "card.last_4"
 
 exporters:
   file:

--- a/_tests/e2e/test.sh
+++ b/_tests/e2e/test.sh
@@ -24,3 +24,16 @@ else
   exit 1
 fi
 
+# Assertions declared here should be also declared in the test-config.yml
+
+CARD_LAST_4=$(tail -n 1 $EXPORTED_TRACE | jq -r '.resourceSpans[].instrumentationLibrarySpans[].spans[].attributes[] | select (.key | contains("card.last_4")) | .value.stringValue')
+
+if [ "$CARD_LAST_4" == "***" ]; then
+  echo "Attribute card.last_4 has been redacted correctly"
+else
+  echo "Attribute card.last_4 hasn't been redacted correctly"
+  exit 1
+fi
+
+
+

--- a/_tests/e2e/test.sh
+++ b/_tests/e2e/test.sh
@@ -18,9 +18,9 @@ while [ ! -f $EXPORTED_TRACE ]; do sleep 1; done
 TRACE_ID=$(tail -n 1 $EXPORTED_TRACE | jq -r ".resourceSpans[0].instrumentationLibrarySpans[0].spans[0].traceId")
 
 if [ "$TRACE_ID" == "cb5a198128c2f36138d3d48c4b72cd0e" ]; then
-  echo "Trace ID has the expected value"
+  echo "Trace ID has the expected value."
 else
-  echo "Unexpected trace ID \"$TRACE_ID\""
+  echo "Unexpected trace ID \"$TRACE_ID\"."
   exit 1
 fi
 
@@ -29,9 +29,9 @@ fi
 CARD_LAST_4=$(tail -n 1 $EXPORTED_TRACE | jq -r '.resourceSpans[].instrumentationLibrarySpans[].spans[].attributes[] | select (.key | contains("card.last_4")) | .value.stringValue')
 
 if [ "$CARD_LAST_4" == "***" ]; then
-  echo "Attribute card.last_4 has been redacted correctly"
+  echo "Attribute card.last_4 has been redacted correctly."
 else
-  echo "Attribute card.last_4 hasn't been redacted correctly"
+  echo "Attribute card.last_4 hasn't been redacted correctly: \"$CARD_LAST_4\"."
   exit 1
 fi
 

--- a/processors/piifilterprocessor/config.go
+++ b/processors/piifilterprocessor/config.go
@@ -8,6 +8,7 @@ import (
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
+// TransportConfig is the config coming directly from the user input.
 type TransportConfig struct {
 	configmodels.ProcessorSettings `mapstructure:",squash"`
 

--- a/processors/piifilterprocessor/config.go
+++ b/processors/piifilterprocessor/config.go
@@ -1,41 +1,117 @@
 package piifilterprocessor
 
 import (
+	"fmt"
+	"regexp"
+
 	"github.com/hypertrace/collector/processors/piifilterprocessor/redaction"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
-type Config struct {
+type TransportConfig struct {
 	configmodels.ProcessorSettings `mapstructure:",squash"`
 
 	// Global redaction strategy. Defaults to Redact
-	RedactStrategy redaction.Strategy `mapstructure:"redaction_strategy"`
+	RedactStrategyName string `mapstructure:"redaction_strategy"`
 
 	// Regexs are the attribute name of which the value will be filtered
 	// when the regex matches the name
-	KeyRegExs []PiiElement `mapstructure:"key_regexs"`
+	KeyRegExs []TransportPiiElement `mapstructure:"key_regexs"`
 
 	// Regexs are the attribute value which will be filtered when
 	// the regex matches
-	ValueRegExs []PiiElement `mapstructure:"value_regexs"`
+	ValueRegExs []TransportPiiElement `mapstructure:"value_regexs"`
 
 	// ComplexData contains all complex data types to filter, such
 	// as json, sql etc
-	ComplexData []PiiComplexData `mapstructure:"complex_data"`
+	ComplexData []TransportPiiComplexData `mapstructure:"complex_data"`
 }
 
-// PiiElement identifies configuration for PII filtering
-type PiiElement struct {
-	Regex          string             `mapstructure:"regex"`
-	RedactStrategy redaction.Strategy `mapstructure:"redaction_strategy"`
-	FQN            bool               `mapstructure:"fqn,omitempty"`
+type TransportPiiElement struct {
+	RegexPattern       string `mapstructure:"regex"`
+	RedactStrategyName string `mapstructure:"redaction_strategy"`
+	FQN                bool   `mapstructure:"fqn,omitempty"`
 }
 
-// PiiComplexData identifes the attribute names which define
-// where the content is and where the content type or
-// the type itself
-type PiiComplexData struct {
+type TransportPiiComplexData struct {
 	Key     string `mapstructure:"key"`
 	Type    string `mapstructure:"type"`
 	TypeKey string `mapstructure:"type_key"`
+}
+
+func (tpe *TransportPiiElement) toPiiElement() (*PiiElement, error) {
+	rp, err := regexp.Compile(tpe.RegexPattern)
+	if err != nil {
+		return nil, fmt.Errorf("error compiling key regex %s already specified", tpe.RegexPattern)
+	}
+
+	return &PiiElement{
+		Regex:          rp,
+		RedactStrategy: mapToRedactionStrategy(tpe.RedactStrategyName),
+		FQN:            tpe.FQN,
+	}, nil
+}
+
+func (tc *TransportConfig) toConfig() (*Config, error) {
+	c := &Config{
+		ProcessorSettings: tc.ProcessorSettings,
+		RedactStrategy:    mapToRedactionStrategy(tc.RedactStrategyName),
+	}
+
+	c.KeyRegExs = make([]PiiElement, len(tc.KeyRegExs))
+	for i, tpe := range tc.KeyRegExs {
+		if pe, err := tpe.toPiiElement(); err == nil {
+			c.KeyRegExs[i] = *pe
+		} else {
+			return nil, err
+		}
+	}
+
+	c.ValueRegExs = make([]PiiElement, len(tc.ValueRegExs))
+	for i, tpe := range tc.ValueRegExs {
+		if pe, err := tpe.toPiiElement(); err == nil {
+			c.ValueRegExs[i] = *pe
+		} else {
+			return nil, err
+		}
+	}
+
+	for _, tpe := range tc.ComplexData {
+		c.ComplexData = append(c.ComplexData, PiiComplexData(tpe))
+	}
+
+	return c, nil
+}
+
+func mapToRedactionStrategy(name string) redaction.Strategy {
+	switch name {
+	case "hash":
+		return redaction.Hash
+	case "raw":
+		return redaction.Raw
+	case "redact":
+		return redaction.Redact
+	default:
+		return redaction.Unknown
+	}
+}
+
+type Config struct {
+	configmodels.ProcessorSettings
+	RedactStrategy redaction.Strategy
+	KeyRegExs      []PiiElement
+	ValueRegExs    []PiiElement
+	ComplexData    []PiiComplexData
+}
+
+type PiiElement struct {
+	Regex          *regexp.Regexp
+	RedactStrategy redaction.Strategy
+	FQN            bool
+}
+
+type PiiComplexData struct {
+	Key     string
+	Type    string
+	TypeKey string
 }

--- a/processors/piifilterprocessor/config.go
+++ b/processors/piifilterprocessor/config.go
@@ -1,6 +1,7 @@
 package piifilterprocessor
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 
@@ -78,6 +79,10 @@ func (tc *TransportConfig) toConfig() (*Config, error) {
 	}
 
 	for _, tpe := range tc.ComplexData {
+		if tpe.Key == "" {
+			return nil, errors.New("key for complex data entry is empty")
+		}
+
 		c.ComplexData = append(c.ComplexData, PiiComplexData(tpe))
 	}
 

--- a/processors/piifilterprocessor/config_test.go
+++ b/processors/piifilterprocessor/config_test.go
@@ -4,6 +4,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/hypertrace/collector/processors/piifilterprocessor/redaction"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -19,4 +20,32 @@ func TestLoadConfig(t *testing.T) {
 	cfg, err := configtest.LoadConfigFile(t, path.Join(".", "testdata", "config.yml"), factories)
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
+}
+
+func TestTransportConfigToConfig(t *testing.T) {
+	tCfg := &TransportConfig{
+		RedactStrategyName: "hash",
+		KeyRegExs: []TransportPiiElement{{
+			RegexPattern:       "[a-z]",
+			RedactStrategyName: "redact",
+		}},
+		ValueRegExs: []TransportPiiElement{{
+			RegexPattern:       "[a-z]+",
+			RedactStrategyName: "raw",
+		}},
+		ComplexData: []TransportPiiComplexData{{
+			Key:  "query",
+			Type: "sql",
+		}},
+	}
+
+	cfg, err := tCfg.toConfig()
+	assert.NoError(t, err)
+	assert.Equal(t, redaction.Hash, cfg.RedactStrategy)
+	assert.Equal(t, "[a-z]", cfg.KeyRegExs[0].Regex.String())
+	assert.Equal(t, redaction.Redact, cfg.KeyRegExs[0].RedactStrategy)
+	assert.Equal(t, "[a-z]+", cfg.ValueRegExs[0].Regex.String())
+	assert.Equal(t, redaction.Raw, cfg.ValueRegExs[0].RedactStrategy)
+	assert.Equal(t, "query", cfg.ComplexData[0].Key)
+	assert.Equal(t, "sql", cfg.ComplexData[0].Type)
 }

--- a/processors/piifilterprocessor/factory.go
+++ b/processors/piifilterprocessor/factory.go
@@ -24,7 +24,7 @@ func NewFactory() component.ProcessorFactory {
 }
 
 func createDefaultConfig() configmodels.Processor {
-	return &Config{
+	return &TransportConfig{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			TypeVal: typeStr,
 			NameVal: typeStr,
@@ -40,7 +40,12 @@ func createTraceProcessor(
 	cfg configmodels.Processor,
 	nextConsumer consumer.TracesConsumer,
 ) (component.TracesProcessor, error) {
-	piiCfg := cfg.(*Config)
+	transportCfg := cfg.(*TransportConfig)
+
+	piiCfg, err := transportCfg.toConfig()
+	if err != nil {
+		return nil, err
+	}
 
 	proc, err := newPIIFilterProcessor(params.Logger, piiCfg)
 	if err != nil {

--- a/processors/piifilterprocessor/filters/cookie/filter_test.go
+++ b/processors/piifilterprocessor/filters/cookie/filter_test.go
@@ -1,6 +1,7 @@
 package cookie
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hypertrace/collector/processors/piifilterprocessor/filters/regexmatcher"
@@ -51,7 +52,7 @@ func TestCookieFilterFiltersSetCookieKey(t *testing.T) {
 
 func newCookieFilter(t *testing.T) *cookieFilter {
 	m, err := regexmatcher.NewMatcher([]regexmatcher.Regex{{
-		Pattern:  "^password$",
+		Regexp:   regexp.MustCompile("^password$"),
 		Redactor: redaction.RedactRedactor,
 	}}, []regexmatcher.Regex{})
 	if err != nil {

--- a/processors/piifilterprocessor/filters/json/filter.go
+++ b/processors/piifilterprocessor/filters/json/filter.go
@@ -55,7 +55,7 @@ func (f *jsonFilter) RedactAttribute(key string, value pdata.AttributeValue) (bo
 	return true, nil
 }
 
-func (f *jsonFilter) filterJSON(value interface{}, matchedRegex *regexmatcher.CompiledRegex, key string, actualKey string, jsonPath string, checked bool) (bool, interface{}) {
+func (f *jsonFilter) filterJSON(value interface{}, matchedRegex *regexmatcher.Regex, key string, actualKey string, jsonPath string, checked bool) (bool, interface{}) {
 	switch tValue := value.(type) {
 	case []interface{}:
 		return f.filterJSONArray(tValue, matchedRegex, key, actualKey, jsonPath, checked)
@@ -68,7 +68,7 @@ func (f *jsonFilter) filterJSON(value interface{}, matchedRegex *regexmatcher.Co
 
 func (f *jsonFilter) filterJSONArray(
 	arrValue []interface{},
-	matchedRegex *regexmatcher.CompiledRegex,
+	matchedRegex *regexmatcher.Regex,
 	key string,
 	actualKey string,
 	jsonPath string,
@@ -95,7 +95,7 @@ func (f *jsonFilter) filterJSONArray(
 
 func (f *jsonFilter) filterJSONMap(
 	mValue map[string]interface{},
-	matchedRegex *regexmatcher.CompiledRegex,
+	matchedRegex *regexmatcher.Regex,
 	_ string,
 	actualKey string,
 	jsonPath string,
@@ -121,7 +121,7 @@ func (f *jsonFilter) filterJSONMap(
 
 func (f *jsonFilter) filterJSONScalar(
 	value interface{},
-	matchedRegex *regexmatcher.CompiledRegex,
+	matchedRegex *regexmatcher.Regex,
 	key string,
 	actualKey string,
 	jsonPath string,

--- a/processors/piifilterprocessor/filters/keyvalue/filter_test.go
+++ b/processors/piifilterprocessor/filters/keyvalue/filter_test.go
@@ -1,6 +1,7 @@
 package keyvalue
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hypertrace/collector/processors/piifilterprocessor/filters/regexmatcher"
@@ -11,7 +12,7 @@ import (
 
 func TestRedactsByKeyWithNoMatchings(t *testing.T) {
 	filter := newFilter(t, []regexmatcher.Regex{{
-		Pattern:  "password",
+		Regexp:   regexp.MustCompile("password"),
 		Redactor: redaction.RedactRedactor,
 	}}, nil)
 
@@ -24,7 +25,7 @@ func TestRedactsByKeyWithNoMatchings(t *testing.T) {
 
 func TestRedactsByKeySuccess(t *testing.T) {
 	filter := newFilter(t, []regexmatcher.Regex{{
-		Pattern:  "^http.request.header.*",
+		Regexp:   regexp.MustCompile("^http.request.header.*"),
 		Redactor: redaction.RedactRedactor,
 	}}, nil)
 
@@ -37,8 +38,8 @@ func TestRedactsByKeySuccess(t *testing.T) {
 
 func TestRedactsByChainOfRegexByValueSuccess(t *testing.T) {
 	filter := newFilter(t, nil, []regexmatcher.Regex{
-		{Pattern: "aaa", Redactor: redaction.RedactRedactor},
-		{Pattern: "bbb", Redactor: redaction.RedactRedactor},
+		{Regexp: regexp.MustCompile("aaa"), Redactor: redaction.RedactRedactor},
+		{Regexp: regexp.MustCompile("bbb"), Redactor: redaction.RedactRedactor},
 	})
 
 	attrValue := pdata.NewAttributeValueString("aaa bbb ccc aaa bbb ccc")
@@ -50,7 +51,7 @@ func TestRedactsByChainOfRegexByValueSuccess(t *testing.T) {
 
 func TestKeyValueRedactsByValueSuccess(t *testing.T) {
 	filter := newFilter(t, nil, []regexmatcher.Regex{{
-		Pattern:  "(?:\\d[ -]*?){13,16}",
+		Regexp:   regexp.MustCompile("(?:\\d[ -]*?){13,16}"),
 		Redactor: redaction.RedactRedactor,
 	}})
 

--- a/processors/piifilterprocessor/filters/regexmatcher/regex.go
+++ b/processors/piifilterprocessor/filters/regexmatcher/regex.go
@@ -1,7 +1,6 @@
 package regexmatcher
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -44,17 +43,15 @@ func (rm *Matcher) FilterKeyRegexs(keyToMatch string, actualKey string, value st
 
 // FilterStringValueRegexs looks into the string value to decide whether filter the value or not
 func (rm *Matcher) FilterStringValueRegexs(value string, key string, path string) (bool, string) {
-	inspectorKey := getFullyQualifiedInspectorKey(key, path)
-
 	filtered := false
 	for _, r := range rm.valueRegExs {
-		filtered, value = rm.replacingRegex(value, inspectorKey, r.Regexp, r.Redactor)
+		filtered, value = rm.replacingRegex(value, r.Regexp, r.Redactor)
 	}
 
 	return filtered, value
 }
 
-func (rm *Matcher) replacingRegex(value string, _ string, regex *regexp.Regexp, redactor redaction.Redactor) (bool, string) {
+func (rm *Matcher) replacingRegex(value string, regex *regexp.Regexp, redactor redaction.Redactor) (bool, string) {
 	matchCount := 0
 
 	filtered := regex.ReplaceAllStringFunc(value, func(src string) string {
@@ -104,16 +101,6 @@ func mapRawToEnriched(rawTag string, path string) (string, string) {
 	}
 
 	return enrichedTag, enrichedPath
-}
-
-func getFullyQualifiedInspectorKey(actualKey string, path string) string {
-	inspectorKey, enrichedPath := mapRawToEnriched(actualKey, path)
-
-	if len(enrichedPath) > 0 {
-		inspectorKey = fmt.Sprintf("%s.%s", inspectorKey, enrichedPath)
-	}
-
-	return inspectorKey
 }
 
 func (rm *Matcher) FilterMatchedKey(redactor redaction.Redactor, actualKey string, value string, path string) (bool, string) {

--- a/processors/piifilterprocessor/filters/regexmatcher/regex_test.go
+++ b/processors/piifilterprocessor/filters/regexmatcher/regex_test.go
@@ -1,33 +1,15 @@
 package regexmatcher
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hypertrace/collector/processors/piifilterprocessor/redaction"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCompileRegexs(t *testing.T) {
-	keyRegexes := []Regex{
-		{
-			Pattern: "^a$",
-		},
-		{
-			Pattern:  "^b$",
-			Redactor: redaction.RedactRedactor,
-		},
-		{
-			Pattern:  "^c$",
-			Redactor: redaction.HashRedactor,
-		},
-	}
-
-	_, err := compileRegexs(keyRegexes)
-	assert.NoError(t, err)
-}
-
 func TestFilterMatchedKey(t *testing.T) {
-	m, _ := NewMatcher([]Regex{{Pattern: "^password$"}}, nil)
+	m, _ := NewMatcher([]Regex{{Regexp: regexp.MustCompile("^password$")}}, nil)
 	isModified, redacted := m.FilterMatchedKey(redaction.RedactRedactor, "http.request.header.password", "abc123", "")
 	assert.True(t, isModified)
 	assert.Equal(t, "***", redacted)

--- a/processors/piifilterprocessor/filters/sql/filter_test.go
+++ b/processors/piifilterprocessor/filters/sql/filter_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestRedactsWithNoSQLMatchings(t *testing.T) {
-	filter := newFilter(t)
+	filter := newFilter()
 
 	attrValue := pdata.NewAttributeValueString("abc123")
 	isRedacted, err := filter.RedactAttribute("unrelated", attrValue)
@@ -19,7 +19,7 @@ func TestRedactsWithNoSQLMatchings(t *testing.T) {
 }
 
 func TestRedactsWithSQL(t *testing.T) {
-	filter := newFilter(t)
+	filter := newFilter()
 	attrValue := pdata.NewAttributeValueString("select password from user where name = 'dave' or name =\"bob\";")
 	isRedacted, err := filter.RedactAttribute("sql.query", attrValue)
 	assert.NoError(t, err)
@@ -28,6 +28,6 @@ func TestRedactsWithSQL(t *testing.T) {
 
 }
 
-func newFilter(t *testing.T) *sqlFilter {
+func newFilter() *sqlFilter {
 	return &sqlFilter{redaction.DefaultRedactor}
 }

--- a/processors/piifilterprocessor/filters/urlencoded/filter_test.go
+++ b/processors/piifilterprocessor/filters/urlencoded/filter_test.go
@@ -2,6 +2,7 @@ package urlencoded
 
 import (
 	"net/url"
+	"regexp"
 	"testing"
 
 	"github.com/hypertrace/collector/processors/piifilterprocessor/filters/regexmatcher"
@@ -34,7 +35,9 @@ func hasRemainingValues(v url.Values) bool {
 }
 
 func TestURLEncodedFilterSuccessOnNoSensitiveValue(t *testing.T) {
-	filter := createURLEncodedFilter(t, []regexmatcher.Regex{{Pattern: "^password$", Redactor: redaction.RedactRedactor}}, []regexmatcher.Regex{})
+	filter := createURLEncodedFilter(t, []regexmatcher.Regex{
+		{Regexp: regexp.MustCompile("^password$"), Redactor: redaction.RedactRedactor},
+	}, []regexmatcher.Regex{})
 
 	v := url.Values{}
 	v.Add("user", "dave")
@@ -51,7 +54,9 @@ func TestURLEncodedFilterSuccessOnNoSensitiveValue(t *testing.T) {
 }
 
 func TestURLEncodedFilterSuccessForSensitiveKey(t *testing.T) {
-	filter := createURLEncodedFilter(t, []regexmatcher.Regex{{Pattern: "^password$", Redactor: redaction.RedactRedactor}}, []regexmatcher.Regex{})
+	filter := createURLEncodedFilter(t, []regexmatcher.Regex{
+		{Regexp: regexp.MustCompile("^password$"), Redactor: redaction.RedactRedactor},
+	}, []regexmatcher.Regex{})
 
 	v := url.Values{}
 	v.Add("user", "dave")
@@ -70,7 +75,9 @@ func TestURLEncodedFilterSuccessForSensitiveKey(t *testing.T) {
 }
 
 func TestURLEncodedFilterSuccessForSensitiveKeyMultiple(t *testing.T) {
-	filter := createURLEncodedFilter(t, []regexmatcher.Regex{{Pattern: "^password$", Redactor: redaction.RedactRedactor}}, []regexmatcher.Regex{})
+	filter := createURLEncodedFilter(t, []regexmatcher.Regex{
+		{Regexp: regexp.MustCompile("^password$"), Redactor: redaction.RedactRedactor},
+	}, []regexmatcher.Regex{})
 
 	v := url.Values{}
 	v.Add("user", "dave")
@@ -90,7 +97,9 @@ func TestURLEncodedFilterSuccessForSensitiveKeyMultiple(t *testing.T) {
 }
 
 func TestURLEncodedFilterSuccessForURL(t *testing.T) {
-	filter := createURLEncodedFilter(t, []regexmatcher.Regex{{Pattern: "^password$", Redactor: redaction.RedactRedactor}}, nil)
+	filter := createURLEncodedFilter(t, []regexmatcher.Regex{
+		{Regexp: regexp.MustCompile("^password$"), Redactor: redaction.RedactRedactor},
+	}, nil)
 
 	testURL := "http://traceshop.dev/login?username=george&password=washington"
 
@@ -110,7 +119,9 @@ func TestURLEncodedFilterSuccessForURL(t *testing.T) {
 }
 
 func TestURLEncodedFilterFailsParsingURL(t *testing.T) {
-	filter := createURLEncodedFilter(t, []regexmatcher.Regex{{Pattern: "^password$"}}, []regexmatcher.Regex{})
+	filter := createURLEncodedFilter(t, []regexmatcher.Regex{
+		{Regexp: regexp.MustCompile("^password$")},
+	}, []regexmatcher.Regex{})
 
 	testURL := "http://x: namedport"
 
@@ -122,7 +133,12 @@ func TestURLEncodedFilterFailsParsingURL(t *testing.T) {
 }
 
 func TestURLEncodedFilterSuccessForSensitiveValue(t *testing.T) {
-	filter := createURLEncodedFilter(t, nil, []regexmatcher.Regex{{Pattern: "^filter_value$", Redactor: redaction.RedactRedactor}})
+	filter := createURLEncodedFilter(t, nil, []regexmatcher.Regex{
+		{
+			Regexp:   regexp.MustCompile("^filter_value$"),
+			Redactor: redaction.RedactRedactor,
+		},
+	})
 
 	v := url.Values{}
 	v.Add("key1", "filter_value")

--- a/processors/piifilterprocessor/processor.go
+++ b/processors/piifilterprocessor/processor.go
@@ -43,7 +43,7 @@ func toRegex(es []PiiElement, globalStrategy redaction.Strategy) []regexmatcher.
 		}
 
 		rs = append(rs, regexmatcher.Regex{
-			Pattern:  e.Regex,
+			Regexp:   e.Regex,
 			Redactor: rd,
 			FQN:      e.FQN,
 		})
@@ -52,10 +52,7 @@ func toRegex(es []PiiElement, globalStrategy redaction.Strategy) []regexmatcher.
 	return rs
 }
 
-func newPIIFilterProcessor(
-	logger *zap.Logger,
-	cfg *Config,
-) (*piiFilterProcessor, error) {
+func newPIIFilterProcessor(logger *zap.Logger, cfg *Config) (*piiFilterProcessor, error) {
 	matcher, err := regexmatcher.NewMatcher(
 		toRegex(cfg.KeyRegExs, cfg.RedactStrategy),
 		toRegex(cfg.ValueRegExs, cfg.RedactStrategy),

--- a/processors/piifilterprocessor/processor_test.go
+++ b/processors/piifilterprocessor/processor_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/hypertrace/collector/processors/piifilterprocessor"
-	"github.com/hypertrace/collector/processors/piifilterprocessor/redaction"
 	"github.com/stretchr/testify/assert"
 
 	stdjson "encoding/json"
@@ -68,28 +67,28 @@ func TestConsumeTraceData(t *testing.T) {
 	logger := zap.New(zapcore.NewNopCore())
 
 	testCases := map[string]struct {
-		config         piifilterprocessor.Config
+		config         piifilterprocessor.TransportConfig
 		inputTraces    pdata.Traces
 		expectedTraces pdata.Traces
 	}{
 		"no filter is applied": {
-			config: piifilterprocessor.Config{
-				KeyRegExs: []piifilterprocessor.PiiElement{
+			config: piifilterprocessor.TransportConfig{
+				KeyRegExs: []piifilterprocessor.TransportPiiElement{
 					{
-						Regex: "^password$",
+						RegexPattern: "^password$",
 					},
 				},
-				RedactStrategy: redaction.Redact,
+				RedactStrategyName: "redact",
 			},
 			inputTraces:    newTraces(newTestSpan("tag1", "abc123")),
 			expectedTraces: newTraces(newTestSpan("tag1", "abc123")),
 		},
 		"auth bearer hash": {
-			config: piifilterprocessor.Config{
-				KeyRegExs: []piifilterprocessor.PiiElement{
-					{Regex: "http.request.header.authorization$"},
+			config: piifilterprocessor.TransportConfig{
+				KeyRegExs: []piifilterprocessor.TransportPiiElement{
+					{RegexPattern: "http.request.header.authorization$"},
 				},
-				RedactStrategy: redaction.Hash,
+				RedactStrategyName: "hash",
 			},
 			inputTraces: newTraces(newTestSpan("http.request.header.authorization", "Bearer abc123")),
 			expectedTraces: newTraces(newTestSpan(
@@ -97,12 +96,12 @@ func TestConsumeTraceData(t *testing.T) {
 			)),
 		},
 		"json filter": {
-			config: piifilterprocessor.Config{
-				KeyRegExs: []piifilterprocessor.PiiElement{
-					{Regex: "^password$"},
+			config: piifilterprocessor.TransportConfig{
+				KeyRegExs: []piifilterprocessor.TransportPiiElement{
+					{RegexPattern: "^password$"},
 				},
-				RedactStrategy: redaction.Redact,
-				ComplexData: []piifilterprocessor.PiiComplexData{
+				RedactStrategyName: "redact",
+				ComplexData: []piifilterprocessor.TransportPiiComplexData{
 					{
 						Key:     "http.request.body",
 						TypeKey: "http.request.headers.content-type",

--- a/processors/piifilterprocessor/testdata/config.yml
+++ b/processors/piifilterprocessor/testdata/config.yml
@@ -2,6 +2,8 @@ receivers:
   examplereceiver:
 
 processors:
+  hypertrace_piifilter:
+    redaction_strategy: "hash"
 
 exporters:
   exampleexporter:


### PR DESCRIPTION
This PR decouples the config data coming from user so we can early apply validations and adds a new layer of config where all the objects are consistent so we don't need to do checks all the time. Also we just transform the redact strategy into actual redactors once.

Ping @pavolloffay @davexroth @mohit-a21 