### PR TITLE
feat(pii/json): adds tests for invalid JSON redacting.

### DIFF
--- a/processors/piifilterprocessor/filters/regexmatcher/regex.go
+++ b/processors/piifilterprocessor/filters/regexmatcher/regex.go
@@ -45,12 +45,17 @@ func (rm *Matcher) FilterKeyRegexs(keyToMatch string, actualKey string, value st
 
 // FilterStringValueRegexs looks into the string value to decide whether filter the value or not
 func (rm *Matcher) FilterStringValueRegexs(value string, key string, path string) (bool, string) {
-	filtered := false
+	var (
+		isRedacted      bool
+		isRegexRedacted bool
+	)
+
 	for _, r := range rm.valueRegExs {
-		filtered, value = rm.replacingRegex(value, r.Regexp, r.Redactor)
+		isRegexRedacted, value = rm.replacingRegex(value, r.Regexp, r.Redactor)
+		isRedacted = isRedacted || isRegexRedacted
 	}
 
-	return filtered, value
+	return isRedacted, value
 }
 
 func (rm *Matcher) replacingRegex(value string, regex *regexp.Regexp, redactor redaction.Redactor) (bool, string) {

--- a/processors/piifilterprocessor/filters/regexmatcher/regex_test.go
+++ b/processors/piifilterprocessor/filters/regexmatcher/regex_test.go
@@ -14,3 +14,10 @@ func TestFilterMatchedKey(t *testing.T) {
 	assert.True(t, isModified)
 	assert.Equal(t, "***", redacted)
 }
+
+//func TestFilterStringValueRegexs(t *testing.T) {
+//	m, _ := NewMatcher(nil, []Regex{{Regexp: regexp.MustCompile("key_or_value")}}, nil)
+//	isModified, redacted := m.FilterMatchedKey(redaction.RedactRedactor, "http.request.header.password", "abc123", "")
+//	assert.True(t, isModified)
+//	assert.Equal(t, "***", redacted)
+//}

--- a/processors/piifilterprocessor/processor.go
+++ b/processors/piifilterprocessor/processor.go
@@ -69,7 +69,7 @@ func newPIIFilterProcessor(logger *zap.Logger, cfg *Config) (*piiFilterProcessor
 	var structuredDataFilters = map[string]filters.Filter{
 		"cookie":     cookie.NewFilter(matcher),
 		"urlencoded": urlencoded.NewFilter(matcher),
-		"json":       json.NewFilter(matcher),
+		"json":       json.NewFilter(matcher, logger),
 		"sql":        sql.NewFilter(redaction.Redactors[cfg.RedactStrategy]),
 	}
 


### PR DESCRIPTION
## Description

This PR adds a feature for still redacting values when the JSON value isn't valid. This is specially useful when length limits in attributes enter into play.

### Testing
Unit testing

Ping @davexroth @pavolloffay 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works