### PR TITLE
add metrics-addr flag for exposing collector telemetry

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -57,6 +57,7 @@ spec:
           command:
             - "/usr/local/bin/hypertrace/collector"
             - "--config=/conf/hypertrace-collector-config.yaml"
+            - "--metrics-addr={{ .Values.metricsAddress }}"
             - "--log-level={{ .Values.logLevel }}"
           ports:
           {{ range $port := .Values.containerPorts }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -6,6 +6,7 @@
 # Deployment and Service
 ###########
 logLevel: INFO
+metricsAddress: "0.0.0.0:8888"
 
 minReadySeconds: 5
 progressDeadlineSeconds: 120


### PR DESCRIPTION
Fixes:
<img width="1769" alt="Screenshot 2021-02-25 at 7 24 29 PM" src="https://user-images.githubusercontent.com/62086374/109176705-16c52b00-77ad-11eb-9228-09366c9da5db.png">

By default, metrics port is binded to localhost and prometheus is not able to scrape it.