### PR TITLE
Add metric pipeline and prometheus exporter to helm values configmap

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -28,7 +28,6 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/config-map.yaml") . | sha256sum }}
         prometheus.io/path: "/metrics"
         prometheus.io/port: "8888"
-        prometheus.io/port_2: "8889"
         prometheus.io/scrape: "true"
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config-map.yaml") . | sha256sum }}
         prometheus.io/path: "/metrics"
-        prometheus.io/port: "8888"
+        prometheus.io/port: "{{ .Values.metricsAddress }}"
         prometheus.io/scrape: "true"
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/config-map.yaml") . | sha256sum }}
         prometheus.io/path: "/metrics"
         prometheus.io/port: "8888"
-        prometheus.io/port/2: "8889"
+        prometheus.io/port_2: "8889"
         prometheus.io/scrape: "true"
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -27,7 +27,8 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config-map.yaml") . | sha256sum }}
         prometheus.io/path: "/metrics"
-        prometheus.io/port: "{{ .Values.metricsAddress }}"
+        prometheus.io/port: "8888"
+        prometheus.io/port/2: "8889"
         prometheus.io/scrape: "true"
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/podmonitor.yaml
+++ b/helm/templates/podmonitor.yaml
@@ -14,26 +14,13 @@ spec:
       {{- toYaml .Values.deploymentSelectorMatchLabels | nindent 6 }}
   podMetricsEndpoints:
   - interval: {{ .Values.podmonitor.interval }}
+    port: {{ .Values.podmonitor.port }}
+    scheme: {{ .Values.podmonitor.scheme }}
+    {{- if .Values.podmonitor.tlsConfig }}
+    tlsConfig:
+      {{- .Values.podmonitor.tlsConfig | nindent 6 }}
+    {{- end }}
     relabelings:
-    - sourceLabels: [ __meta_kubernetes_pod_annotation_prometheus_io_scrape ]
-      regex: "true"
-      replacement: $1
-      action: keep
-    - sourceLabels: [ __meta_kubernetes_pod_controller_kind, __meta_kubernetes_pod_phase ]
-      regex: "Job;Succeeded"
-      action: drop
-    - regex: container
-      action: labeldrop
-    - sourceLabels: [ __meta_kubernetes_pod_annotation_prometheus_io_path ]
-      regex: (.+)
-      targetLabel: __metrics_path__
-      replacement: $1
-      action: replace
-    - sourceLabels: [ __address__, __meta_kubernetes_pod_annotation_prometheus_io_port_2 ]
-      regex: ([^:]+)(?::\d+)?;(\d+)
-      targetLabel: __address__
-      replacement: $1:$2
-      action: replace
     - regex: __meta_kubernetes_pod_label_(.+)
       replacement: $1
       action: labelmap

--- a/helm/templates/podmonitor.yaml
+++ b/helm/templates/podmonitor.yaml
@@ -13,8 +13,40 @@ spec:
     matchLabels:
       {{- toYaml .Values.deploymentSelectorMatchLabels | nindent 6 }}
   podMetricsEndpoints:
-#    - port: jmx-prometheus TODO: add relabeling for address
-      interval: {{ .Values.podmonitor.interval }}
+  - interval: {{ .Values.podmonitor.interval }}
+    relabelings:
+    - sourceLabels: [ __meta_kubernetes_pod_annotation_prometheus_io_scrape ]
+      regex: "true"
+      replacement: $1
+      action: keep
+    - sourceLabels: [ __meta_kubernetes_pod_controller_kind, __meta_kubernetes_pod_phase ]
+      regex: "Job;Succeeded"
+      action: drop
+    - regex: container
+      action: labeldrop
+    - sourceLabels: [ __meta_kubernetes_pod_annotation_prometheus_io_path ]
+      regex: (.+)
+      targetLabel: __metrics_path__
+      replacement: $1
+      action: replace
+    - sourceLabels: [ __address__, __meta_kubernetes_pod_annotation_prometheus_io_port_2 ]
+      regex: ([^:]+)(?::\d+)?;(\d+)
+      targetLabel: __address__
+      replacement: $1:$2
+      action: replace
+    - regex: __meta_kubernetes_pod_label_(.+)
+      replacement: $1
+      action: labelmap
+    - sourceLabels: [ __meta_kubernetes_namespace ]
+      regex: (.*)
+      targetLabel: namespace
+      replacement: $1
+      action: replace
+    - sourceLabels: [ __meta_kubernetes_pod_name ]
+      regex: (.*)
+      targetLabel: pod
+      replacement: $1
+      action: replace
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/helm/templates/podmonitor.yaml
+++ b/helm/templates/podmonitor.yaml
@@ -1,0 +1,21 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.podmonitor.enabled ) }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    monitoring: shared
+spec:
+  jobLabel: hypertrace-collector-pods
+  selector:
+    matchLabels:
+      {{- toYaml .Values.deploymentSelectorMatchLabels | nindent 6 }}
+  podMetricsEndpoints:
+#    - port: jmx-prometheus TODO: add relabeling for address
+      interval: {{ .Values.podmonitor.interval }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -34,6 +34,10 @@ containerPorts:
     containerPort: 14250
   - name: http-zipkin
     containerPort: 9411
+  - name: http-promint
+    containerPort: 8888
+  - name: http-promexp
+    containerPort: 8889
 
 service:
   type: LoadBalancer
@@ -199,3 +203,5 @@ kafka-topic-creator:
 podmonitor:
   enabled: false
   interval: 15s
+  port: "http-promexp"
+  scheme: "http"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -34,9 +34,11 @@ containerPorts:
     containerPort: 14250
   - name: http-zipkin
     containerPort: 9411
-  - name: http-promint
+#   Port for exposing internal metrics to prometheus. Should match with {{ .Values.metricsAddress }}
+  - name: http-prom-int
     containerPort: 8888
-  - name: http-promexp
+#   Port for exposing prometheus exporter metrics. Should match with {{ .Values.configmap.data.exporters.prometheus.endpoint }}
+  - name: http-prom-exp
     containerPort: 8889
 
 service:
@@ -203,5 +205,5 @@ kafka-topic-creator:
 podmonitor:
   enabled: false
   interval: 15s
-  port: "http-promexp"
+  port: "http-prom-exp"
   scheme: "http"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -148,14 +148,6 @@ configMap:
             endpoint: "0.0.0.0:14250"
           thrift_http:
             endpoint: "0.0.0.0:14268"
-      # Collect own metrics
-      prometheus:
-        config:
-          scrape_configs:
-            - job_name: "otel-collector"
-              scrape_interval: 10s
-              static_configs:
-                - targets: ["0.0.0.0:8888"]
     processors:
       batch: {}
 
@@ -166,6 +158,8 @@ configMap:
           - bootstrap:9092
         topic: jaeger-spans
         encoding: jaeger_proto
+      prometheus:
+        endpoint: "0.0.0.0:8889"
 
     service:
       extensions: [health_check, pprof, zpages]
@@ -174,6 +168,10 @@ configMap:
           receivers: [otlp, opencensus, jaeger, zipkin]
           processors: [batch]
           exporters: [kafka]
+        metrics:
+          receivers: [ otlp ]
+          processors: [ batch ]
+          exporters: [ prometheus ]
 
 hpa:
   enabled: false

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -195,3 +195,7 @@ kafka-topic-creator:
   imagePullSecrets: []
   podAnnotations:
     sidecar.istio.io/inject: "false"
+
+podmonitor:
+  enabled: false
+  interval: 15s


### PR DESCRIPTION
Adding metric pipeline for receiving metrics from traceable-agent/local-collector and prometheus exporter to expose these metrics. 

Also, added a podmonitor resource to read metrics from this collector by prometheus operator