### PR TITLE
Add resource attributes to metric labels in prometheus exporter

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -169,6 +169,9 @@ configMap:
           level: 5 #Required only for gzip 1-9
       prometheus:
         endpoint: "0.0.0.0:8889"
+        #For converting resource attributes to metric labels
+        resource_to_telemetry_conversion:
+          enabled: true
 
     service:
       extensions: [health_check, pprof, zpages]


### PR DESCRIPTION
Prometheus exporter does not convert resource attributes to metric labels by default. Updating helm values config to add these resource attributes to metric labels as in prometheus exporter