### PR TITLE
fix: kafkaexporter:- log span info early when producer maxMessageBytes is exceeded

### DIFF
--- a/exporter/kafkaexporter/config.modified.go
+++ b/exporter/kafkaexporter/config.modified.go
@@ -54,8 +54,8 @@ type Config struct {
 	// Compression defines the compression method and compression level, if applicable.
 	Compression Compression `mapstructure:"compression"`
 
-	// Debug mode. Log info for spans that exceed Producer.MaxMessageBytes early.
-	DebugMode bool `mapstructure:"debug_mode"`
+	// Debug. Log info for spans that exceed Producer.MaxMessageBytes early.
+	Debug bool `mapstructure:"debug"`
 }
 
 // Metadata defines configuration for retrieving metadata from the broker.

--- a/exporter/kafkaexporter/config.modified.go
+++ b/exporter/kafkaexporter/config.modified.go
@@ -53,6 +53,9 @@ type Config struct {
 
 	// Compression defines the compression method and compression level, if applicable.
 	Compression Compression `mapstructure:"compression"`
+
+	// Debug mode. Log info for spans that exceed Producer.MaxMessageBytes early.
+	DebugMode bool `mapstructure:"debug_mode"`
 }
 
 // Metadata defines configuration for retrieving metadata from the broker.

--- a/exporter/kafkaexporter/config_modified_test.go
+++ b/exporter/kafkaexporter/config_modified_test.go
@@ -79,5 +79,6 @@ func TestLoadConfig(t *testing.T) {
 			Codec: "gzip",
 			Level: 8,
 		},
+		DebugMode: true,
 	}, c)
 }

--- a/exporter/kafkaexporter/config_modified_test.go
+++ b/exporter/kafkaexporter/config_modified_test.go
@@ -79,6 +79,6 @@ func TestLoadConfig(t *testing.T) {
 			Codec: "gzip",
 			Level: 8,
 		},
-		DebugMode: true,
+		Debug: true,
 	}, c)
 }

--- a/exporter/kafkaexporter/jaeger_marshaler_debug.go
+++ b/exporter/kafkaexporter/jaeger_marshaler_debug.go
@@ -1,0 +1,151 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkaexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
+
+// Similar to jaegerMarshaler except we log details of spans greater than producer maxMessageBytes. When doing otel
+// upgrades pull in updates from jaeger_mashaler.go:Marshal function
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/Shopify/sarama"
+	jaegerproto "github.com/jaegertracing/jaeger/model"
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/multierr"
+
+	jaegertranslator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
+)
+
+const (
+	maximumRecordOverhead   = 5*binary.MaxVarintLen32 + binary.MaxVarintLen64 + 1
+	producerMessageOverhead = 26 // the metadata overhead of CRC, flags, etc.
+)
+
+type jaegerMarshalerDebug struct {
+	marshaler       jaegerSpanMarshaler
+	version         sarama.KafkaVersion
+	maxMessageBytes int
+}
+
+var _ TracesMarshaler = (*jaegerMarshaler)(nil)
+
+func (j jaegerMarshalerDebug) Marshal(traces pdata.Traces, topic string) ([]*sarama.ProducerMessage, error) {
+	batches, err := jaegertranslator.InternalTracesToJaegerProto(traces)
+	if err != nil {
+		return nil, err
+	}
+	var messages []*sarama.ProducerMessage
+
+	var errs error
+	for _, batch := range batches {
+		for _, span := range batch.Spans {
+			span.Process = batch.Process
+			bts, err := j.marshaler.marshal(span)
+			// continue to process spans that can be serialized
+			if err != nil {
+				errs = multierr.Append(errs, err)
+				continue
+			}
+			key := []byte(span.TraceID.String())
+			msg := &sarama.ProducerMessage{
+				Topic: topic,
+				Value: sarama.ByteEncoder(bts),
+				Key:   sarama.ByteEncoder(key),
+			}
+			// Computed the same way as in https://github.com/Shopify/sarama/blob/a060ecaa8887587485754af088bd8a521f6d55e9/async_producer.go#L233
+			messageSize := byteSize(msg, j.version)
+			if messageSize > j.maxMessageBytes {
+				// Log span info for a span that exceeds the max message size
+				// We log instead of throwing an error since the caller for this tracesPusher() will return an error and not even
+				// send those messages that didn't exceed the max message size.
+				log.Printf("span exceeds max message size: %d vs %d. span%s\n", messageSize, j.maxMessageBytes, spanAsString(span))
+			}
+			messages = append(messages, msg)
+		}
+	}
+	return messages, errs
+}
+
+func (j jaegerMarshalerDebug) Encoding() string {
+	return j.marshaler.encoding()
+}
+
+func spanAsString(span *jaegerproto.Span) string {
+	var sb strings.Builder
+
+	sb.WriteString("{")
+	sb.WriteString(fmt.Sprintf("trace_id: %s, ", span.TraceID.String()))
+	sb.WriteString(fmt.Sprintf("span_id: %s, ", span.SpanID.String()))
+	sb.WriteString(fmt.Sprintf("name: %s, ", span.OperationName))
+	sb.WriteString(fmt.Sprintf("start_time: %s, ", span.StartTime.String()))
+	sb.WriteString(fmt.Sprintf("duration: %s, ", span.Duration.String()))
+	if span.Process == nil {
+		sb.WriteString("process: nil")
+	} else {
+		sb.WriteString("process: {")
+		sb.WriteString(fmt.Sprintf("service_name: %s, ", span.Process.ServiceName))
+		sb.WriteString("tags: [")
+		for _, kv := range span.Process.Tags {
+			sb.WriteString("{")
+			sb.WriteString(fmt.Sprintf("key: %s, ", kv.Key))
+			sb.WriteString(fmt.Sprintf("value: %s", valueToString(kv)))
+			sb.WriteString("},")
+		}
+		sb.WriteString("]")
+		sb.WriteString("}")
+	}
+	sb.WriteString("}")
+
+	return sb.String()
+}
+
+func valueToString(kv jaegerproto.KeyValue) string {
+	if kv.VType == jaegerproto.ValueType_STRING {
+		return kv.GetVStr()
+	} else if kv.VType == jaegerproto.ValueType_BOOL {
+		return strconv.FormatBool(kv.GetVBool())
+	} else if kv.VType == jaegerproto.ValueType_INT64 {
+		return strconv.FormatInt(kv.GetVInt64(), 10)
+	} else if kv.VType == jaegerproto.ValueType_FLOAT64 {
+		return fmt.Sprintf("%f", kv.GetVFloat64())
+	} else if kv.VType == jaegerproto.ValueType_BINARY {
+		return hex.EncodeToString(kv.GetVBinary())
+	} else {
+		return ""
+	}
+}
+
+func byteSize(m *sarama.ProducerMessage, v sarama.KafkaVersion) int {
+	var size int
+	if v.IsAtLeast(sarama.V0_11_0_0) {
+		size = maximumRecordOverhead
+		for _, h := range m.Headers {
+			size += len(h.Key) + len(h.Value) + 2*binary.MaxVarintLen32
+		}
+	} else {
+		size = producerMessageOverhead
+	}
+	if m.Key != nil {
+		size += m.Key.Length()
+	}
+	if m.Value != nil {
+		size += m.Value.Length()
+	}
+	return size
+}

--- a/exporter/kafkaexporter/jaeger_marshaler_debug.go
+++ b/exporter/kafkaexporter/jaeger_marshaler_debug.go
@@ -1,17 +1,3 @@
-// Copyright 2020 The OpenTelemetry Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package kafkaexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
 
 // Similar to jaegerMarshaler except we log details of spans greater than producer maxMessageBytes. When doing otel

--- a/exporter/kafkaexporter/jaeger_marshaler_debug_test.go
+++ b/exporter/kafkaexporter/jaeger_marshaler_debug_test.go
@@ -1,17 +1,3 @@
-// Copyright 2020 The OpenTelemetry Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package kafkaexporter
 
 import (

--- a/exporter/kafkaexporter/jaeger_marshaler_debug_test.go
+++ b/exporter/kafkaexporter/jaeger_marshaler_debug_test.go
@@ -1,0 +1,136 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkaexporter
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/model/pdata"
+
+	jaegertranslator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
+)
+
+func TestJaegerMarshalerDebug(t *testing.T) {
+	maxMessageBytes := 1024
+	td := pdata.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().Insert("test-key", pdata.NewAttributeValueString("test-val"))
+	ils := rs.InstrumentationLibrarySpans().AppendEmpty()
+
+	// Will add this span to the messages queue to export
+	span := ils.Spans().AppendEmpty()
+	span.SetName("foo")
+	span.SetStartTimestamp(pdata.Timestamp(10))
+	span.SetEndTimestamp(pdata.Timestamp(20))
+	span.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+	span.SetSpanID(pdata.NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+
+	// Create a string whose size is maxMessageBytes
+	var b strings.Builder
+	b.Grow(maxMessageBytes)
+	for i := 0; i < maxMessageBytes; i++ {
+		b.WriteString("a")
+	}
+	s := b.String()
+
+	// Will log on this span that exceeds max message size.
+	span = ils.Spans().AppendEmpty()
+	span.SetName("bar")
+	span.SetStartTimestamp(pdata.Timestamp(100))
+	span.SetEndTimestamp(pdata.Timestamp(225))
+	span.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+	span.SetSpanID(pdata.NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+	span.Attributes().Insert("big-tag", pdata.NewAttributeValueString(s))
+
+	batches, err := jaegertranslator.InternalTracesToJaegerProto(td)
+	require.NoError(t, err)
+
+	jsonMarshaler := &jsonpb.Marshaler{}
+
+	batches[0].Spans[0].Process = batches[0].Process
+	jaegerProtoBytes0, err := batches[0].Spans[0].Marshal()
+	messageKey := []byte(batches[0].Spans[0].TraceID.String())
+	require.NoError(t, err)
+	require.NotNil(t, jaegerProtoBytes0)
+
+	jsonByteBuffer0 := new(bytes.Buffer)
+	require.NoError(t, jsonMarshaler.Marshal(jsonByteBuffer0, batches[0].Spans[0]))
+
+	batches[0].Spans[1].Process = batches[0].Process
+	jaegerProtoBytes1, err := batches[0].Spans[1].Marshal()
+	require.NoError(t, err)
+	require.NotNil(t, jaegerProtoBytes1)
+
+	jsonByteBuffer1 := new(bytes.Buffer)
+	require.NoError(t, jsonMarshaler.Marshal(jsonByteBuffer1, batches[0].Spans[1]))
+
+	tests := []struct {
+		unmarshaler TracesMarshaler
+		encoding    string
+		messages    []*sarama.ProducerMessage
+	}{
+		{
+			unmarshaler: jaegerMarshalerDebug{
+				marshaler:       jaegerProtoSpanMarshaler{},
+				version:         sarama.V2_0_0_0,
+				maxMessageBytes: maxMessageBytes,
+			},
+			encoding: "jaeger_proto",
+			messages: []*sarama.ProducerMessage{
+				{Topic: "topic", Value: sarama.ByteEncoder(jaegerProtoBytes0), Key: sarama.ByteEncoder(messageKey)},
+				{Topic: "topic", Value: sarama.ByteEncoder(jaegerProtoBytes1), Key: sarama.ByteEncoder(messageKey)}},
+		},
+		{
+			unmarshaler: jaegerMarshalerDebug{
+				marshaler: jaegerJSONSpanMarshaler{
+					pbMarshaler: &jsonpb.Marshaler{},
+				},
+				version:         sarama.V2_0_0_0,
+				maxMessageBytes: maxMessageBytes,
+			},
+			encoding: "jaeger_json",
+			messages: []*sarama.ProducerMessage{
+				{Topic: "topic", Value: sarama.ByteEncoder(jsonByteBuffer0.Bytes()), Key: sarama.ByteEncoder(messageKey)},
+				{Topic: "topic", Value: sarama.ByteEncoder(jsonByteBuffer1.Bytes()), Key: sarama.ByteEncoder(messageKey)},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.encoding, func(t *testing.T) {
+			messages, err := test.unmarshaler.Marshal(td, "topic")
+			require.NoError(t, err)
+			assert.Equal(t, test.messages, messages)
+			assert.Equal(t, test.encoding, test.unmarshaler.Encoding())
+		})
+	}
+}
+
+func TestJaegerMarshalerDebug_error_covert_traceID(t *testing.T) {
+	marshaler := jaegerMarshalerDebug{
+		marshaler: jaegerProtoSpanMarshaler{},
+	}
+	td := pdata.NewTraces()
+	td.ResourceSpans().AppendEmpty().InstrumentationLibrarySpans().AppendEmpty().Spans().AppendEmpty()
+	// fails in zero traceID
+	messages, err := marshaler.Marshal(td, "topic")
+	require.Error(t, err)
+	assert.Nil(t, messages)
+}

--- a/exporter/kafkaexporter/kafka_exporter.modified.go
+++ b/exporter/kafkaexporter/kafka_exporter.modified.go
@@ -179,7 +179,7 @@ func newTracesExporter(config Config, set component.ExporterCreateSettings, mars
 	if marshaler == nil {
 		return nil, errUnrecognizedEncoding
 	}
-	if config.DebugMode && config.Encoding == "jaeger_proto" {
+	if config.Debug && config.Encoding == "jaeger_proto" {
 		v := sarama.V2_0_0_0
 		if config.ProtocolVersion != "" {
 			version, err := sarama.ParseKafkaVersion(config.ProtocolVersion)

--- a/exporter/kafkaexporter/kafka_exporter.modified.go
+++ b/exporter/kafkaexporter/kafka_exporter.modified.go
@@ -172,11 +172,26 @@ func newMetricsExporter(config Config, set component.ExporterCreateSettings, mar
 
 }
 
-// newTracesExporter creates Kafka exporter.
+// newTracesExporter creates Kafka exporter. If debug mode is turned on and we are using "jaeger_proto" message encoding, we will switch out the
+// marshaler to jaegerMarshalerDebug which logs spans details for spans greater than config.Producer.MaxMessageBytes.
 func newTracesExporter(config Config, set component.ExporterCreateSettings, marshalers map[string]TracesMarshaler) (*kafkaTracesProducer, error) {
 	marshaler := marshalers[config.Encoding]
 	if marshaler == nil {
 		return nil, errUnrecognizedEncoding
+	}
+	if config.DebugMode && config.Encoding == "jaeger_proto" {
+		v := sarama.V2_0_0_0
+		if config.ProtocolVersion != "" {
+			version, err := sarama.ParseKafkaVersion(config.ProtocolVersion)
+			if err == nil {
+				v = version
+			}
+		}
+		marshaler = jaegerMarshalerDebug{
+			marshaler:       jaegerProtoSpanMarshaler{},
+			version:         v,
+			maxMessageBytes: config.Producer.MaxMessageBytes,
+		}
 	}
 	producer, err := newSaramaProducer(config)
 	if err != nil {

--- a/exporter/kafkaexporter/testdata/config_modified.yaml
+++ b/exporter/kafkaexporter/testdata/config_modified.yaml
@@ -28,7 +28,7 @@ exporters:
     compression:
       codec: gzip
       level: 8
-    debug_mode: true
+    debug: true
 
 processors:
   nop:

--- a/exporter/kafkaexporter/testdata/config_modified.yaml
+++ b/exporter/kafkaexporter/testdata/config_modified.yaml
@@ -28,6 +28,7 @@ exporters:
     compression:
       codec: gzip
       level: 8
+    debug_mode: true
 
 processors:
   nop:


### PR DESCRIPTION
## Description
We want to diagnose why the kafkaexporter is failing to export some messages because they are too large. 
```
2022-01-12T14:10:33.425Z  info  exporterhelper/queued_retry.go:215  Exporting failed. Will retry the request after interval.  {"kind": "exporter", "name": "kafka", "error": "Failed to deliver 1 messages due to kafka server: Message was too large, server rejected it to avoid allocation error.", "interval": "15.687771456s"}
2022-01-12T14:10:45.128Z  info  exporterhelper/queued_retry.go:215  Exporting failed. Will retry the request after interval.  {"kind": "exporter", "name": "kafka", "error": "Failed to deliver 1 messages due to kafka server: Message was too large, server rejected it to avoid allocation error.", "interval": "4.033118042s"}
```
Since for this exporter, each span is converted to a message, the implication is that some spans when encoded using "jaeger_proto" are larger that the Producer.MaxMessageBytes which by default is 1M. So some spans are 1MB or more in size.

### Testing
Added some tests for the new debug mashaler.

### Checklist:
- [✅  ] My changes generate no new warnings
- [ ✅ ] I have added tests that prove my fix is effective or that my feature works


