### PR TITLE
fix: kafkaexporter:- log span tags when debug and dump_span_attributes are set

### DIFF
--- a/exporter/kafkaexporter/config.modified.go
+++ b/exporter/kafkaexporter/config.modified.go
@@ -56,6 +56,10 @@ type Config struct {
 
 	// Debug. Log info for spans that exceed Producer.MaxMessageBytes early.
 	Debug bool `mapstructure:"debug"`
+
+	// Dump all span attributes. Works when Debug above is set to true. Will dump
+	// all the span attribute values for spans that exceed Producer.MaxMessageBytes
+	DumpSpanAttributes bool `mapstructure:"dump_span_attributes"`
 }
 
 // Metadata defines configuration for retrieving metadata from the broker.

--- a/exporter/kafkaexporter/config_modified_test.go
+++ b/exporter/kafkaexporter/config_modified_test.go
@@ -79,6 +79,7 @@ func TestLoadConfig(t *testing.T) {
 			Codec: "gzip",
 			Level: 8,
 		},
-		Debug: true,
+		Debug:              true,
+		DumpSpanAttributes: true,
 	}, c)
 }

--- a/exporter/kafkaexporter/kafka_exporter.modified.go
+++ b/exporter/kafkaexporter/kafka_exporter.modified.go
@@ -188,9 +188,10 @@ func newTracesExporter(config Config, set component.ExporterCreateSettings, mars
 			}
 		}
 		marshaler = jaegerMarshalerDebug{
-			marshaler:       jaegerProtoSpanMarshaler{},
-			version:         v,
-			maxMessageBytes: config.Producer.MaxMessageBytes,
+			marshaler:          jaegerProtoSpanMarshaler{},
+			version:            v,
+			maxMessageBytes:    config.Producer.MaxMessageBytes,
+			dumpSpanAttributes: config.DumpSpanAttributes,
 		}
 	}
 	producer, err := newSaramaProducer(config)

--- a/exporter/kafkaexporter/testdata/config_modified.yaml
+++ b/exporter/kafkaexporter/testdata/config_modified.yaml
@@ -29,6 +29,7 @@ exporters:
       codec: gzip
       level: 8
     debug: true
+    dump_span_attributes: true
 
 processors:
   nop:


### PR DESCRIPTION
## Description
Have the option to log the tag value's length or actual value depending on if dump_span_attributes is set. This is for the scenario where a span exceeds the producer maxMessageBytes. Follow up to https://github.com/hypertrace/hypertrace-collector/pull/69

### Checklist:
- [✅  ] My changes generate no new warnings
- [✅  ] I have added tests that prove my fix is effective or that my feature works
