### PR TITLE
fix: cure large spans by truncating big tag values to a reasonable size

### DIFF
--- a/exporter/kafkaexporter/config.modified.go
+++ b/exporter/kafkaexporter/config.modified.go
@@ -55,10 +55,12 @@ type Config struct {
 	Compression Compression `mapstructure:"compression"`
 
 	// Debug. Log info for spans that exceed Producer.MaxMessageBytes early.
+	// [Deprecated]
 	Debug bool `mapstructure:"debug"`
 
 	// Dump all span attributes. Works when Debug above is set to true. Will dump
 	// all the span attribute values for spans that exceed Producer.MaxMessageBytes
+	// [Deprecated]
 	DumpSpanAttributes bool `mapstructure:"dump_span_attributes"`
 
 	// SpanCuring defines config to "cure" large spans that exceed Producer.MaxMessageBytes so that

--- a/exporter/kafkaexporter/config.modified.go
+++ b/exporter/kafkaexporter/config.modified.go
@@ -60,6 +60,10 @@ type Config struct {
 	// Dump all span attributes. Works when Debug above is set to true. Will dump
 	// all the span attribute values for spans that exceed Producer.MaxMessageBytes
 	DumpSpanAttributes bool `mapstructure:"dump_span_attributes"`
+
+	// Cure spans. This means that when Debug above is turned on, if a span exceeds Producer.MaxMessageBytes
+	// we will loop through its tags and truncate the values whose values are large to 128KiB
+	CureSpans bool `mapstructure:"cure_spans"`
 }
 
 // Metadata defines configuration for retrieving metadata from the broker.

--- a/exporter/kafkaexporter/config.modified.go
+++ b/exporter/kafkaexporter/config.modified.go
@@ -61,9 +61,9 @@ type Config struct {
 	// all the span attribute values for spans that exceed Producer.MaxMessageBytes
 	DumpSpanAttributes bool `mapstructure:"dump_span_attributes"`
 
-	// Cure spans. This means that when Debug above is turned on, if a span exceeds Producer.MaxMessageBytes
-	// we will loop through its tags and truncate the values whose values are large to 128KiB
-	CureSpans bool `mapstructure:"cure_spans"`
+	// SpanCuring defines config to "cure" large spans that exceed Producer.MaxMessageBytes so that
+	// they are able to be exported
+	SpanCuring SpanCuring `mapstructure:"span_curing"`
 }
 
 // Metadata defines configuration for retrieving metadata from the broker.
@@ -102,6 +102,21 @@ type MetadataRetry struct {
 	// How long to wait for leader election to occur before retrying
 	// (default 250ms). Similar to the JVM's `retry.backoff.ms`.
 	Backoff time.Duration `mapstructure:"backoff"`
+}
+
+// SpanCuring defines config to be applied to large spans that exceed Producer.MaxMessageBytes.
+// If we realize that the span about to be exported is larger than Producer.MaxMessageBytes we
+// attempt to cure it by truncating the attribute values that exceed MaxAttributeValueSize size.
+type SpanCuring struct {
+	Enabled bool `mapstructure:"enabled"`
+	// Drop spans that cannot be cured. A good idea since these spans will never be exported and will
+	// end up on the retry queue.
+	DropSpans bool `mapstructure:"drop_spans"`
+	// Max size in bytes for attribute values. Affects string and byte array value types.
+	MaxAttributeValueSize int `mapstructure:"max_attribute_value_size"`
+	// Dump all span attributes. Will dump all the span attribute values for
+	// spans that exceed Producer.MaxMessageBytes
+	DumpSpanAttributes bool `mapstructure:"dump_span_attributes"`
 }
 
 var _ config.Exporter = (*Config)(nil)

--- a/exporter/kafkaexporter/config_modified_test.go
+++ b/exporter/kafkaexporter/config_modified_test.go
@@ -81,5 +81,6 @@ func TestLoadConfig(t *testing.T) {
 		},
 		Debug:              true,
 		DumpSpanAttributes: true,
+		CureSpans:          true,
 	}, c)
 }

--- a/exporter/kafkaexporter/config_modified_test.go
+++ b/exporter/kafkaexporter/config_modified_test.go
@@ -81,6 +81,11 @@ func TestLoadConfig(t *testing.T) {
 		},
 		Debug:              true,
 		DumpSpanAttributes: true,
-		CureSpans:          true,
+		SpanCuring: SpanCuring{
+			Enabled:               true,
+			DropSpans:             true,
+			MaxAttributeValueSize: 131072,
+			DumpSpanAttributes:    true,
+		},
 	}, c)
 }

--- a/exporter/kafkaexporter/jaeger_marshaler_curer.go
+++ b/exporter/kafkaexporter/jaeger_marshaler_curer.go
@@ -28,7 +28,7 @@ const (
 	truncationTagSuffix = ".htcollector.truncated"
 )
 
-type jaegerMarshalerDebug struct {
+type jaegerMarshalerCurer struct {
 	marshaler             jaegerSpanMarshaler
 	version               sarama.KafkaVersion
 	maxMessageBytes       int
@@ -37,9 +37,9 @@ type jaegerMarshalerDebug struct {
 	dropSpans             bool
 }
 
-var _ TracesMarshaler = (*jaegerMarshalerDebug)(nil)
+var _ TracesMarshaler = (*jaegerMarshalerCurer)(nil)
 
-func (j jaegerMarshalerDebug) Marshal(traces pdata.Traces, topic string) ([]*sarama.ProducerMessage, error) {
+func (j jaegerMarshalerCurer) Marshal(traces pdata.Traces, topic string) ([]*sarama.ProducerMessage, error) {
 	batches, err := jaegertranslator.InternalTracesToJaegerProto(traces)
 	if err != nil {
 		return nil, err
@@ -88,11 +88,11 @@ func (j jaegerMarshalerDebug) Marshal(traces pdata.Traces, topic string) ([]*sar
 	return messages, errs
 }
 
-func (j jaegerMarshalerDebug) Encoding() string {
+func (j jaegerMarshalerCurer) Encoding() string {
 	return j.marshaler.encoding()
 }
 
-func (j jaegerMarshalerDebug) spanAsString(span *jaegerproto.Span) string {
+func (j jaegerMarshalerCurer) spanAsString(span *jaegerproto.Span) string {
 	var sb strings.Builder
 
 	sb.WriteString("{")
@@ -132,7 +132,7 @@ func (j jaegerMarshalerDebug) spanAsString(span *jaegerproto.Span) string {
 	return sb.String()
 }
 
-func (j jaegerMarshalerDebug) cureSpan(span *jaegerproto.Span, topic string) (*sarama.ProducerMessage, error) {
+func (j jaegerMarshalerCurer) cureSpan(span *jaegerproto.Span, topic string) (*sarama.ProducerMessage, error) {
 	attributeValueSize := j.maxAttributeValueSize
 	truncatedKeysSoFar := make(map[string]bool)
 	// Go through the attributes and get the indices of tags whose values exceed attributeValueSize

--- a/exporter/kafkaexporter/jaeger_marshaler_curer.go
+++ b/exporter/kafkaexporter/jaeger_marshaler_curer.go
@@ -162,14 +162,14 @@ func (j jaegerMarshalerCurer) cureSpan(span *jaegerproto.Span, topic string) (*s
 			// replace the kv in the slice with one whose value is truncated.
 			span.Tags[i] = kv
 			truncatedKey := kv.Key + truncationTagSuffix
-			// append the ".truncated" attribute to the list of truncated keys if it's not already been seen before.
+			// append the ".htcollector.truncated" attribute to the list of truncated keys if it has not already been seen before.
 			if !truncatedKeysSoFar[truncatedKey] {
 				truncatedKeys = append(truncatedKeys, kv.Key+truncationTagSuffix)
 				truncatedKeysSoFar[truncatedKey] = true
 			}
 		}
 
-		// append the ".truncated" attributes to the span list.
+		// append the ".htcollector.truncated" attributes to the span list.
 		for _, k := range truncatedKeys {
 			kv := jaegerproto.KeyValue{
 				Key:   k,

--- a/exporter/kafkaexporter/jaeger_marshaler_curer_test.go
+++ b/exporter/kafkaexporter/jaeger_marshaler_curer_test.go
@@ -16,7 +16,7 @@ import (
 	jaegertranslator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
 )
 
-func TestJaegerMarshalerDebugCureSpans(t *testing.T) {
+func TestJaegerMarshalerCurer(t *testing.T) {
 	maxMessageBytes := 1024
 	maxAttributeValueSize := 256
 	jsonMarshaler := &jsonpb.Marshaler{}
@@ -114,7 +114,7 @@ func TestJaegerMarshalerDebugCureSpans(t *testing.T) {
 		messages    []*sarama.ProducerMessage
 	}{
 		{
-			unmarshaler: jaegerMarshalerDebug{
+			unmarshaler: jaegerMarshalerCurer{
 				marshaler:             jaegerProtoSpanMarshaler{},
 				version:               sarama.V2_0_0_0,
 				maxMessageBytes:       maxMessageBytes,
@@ -128,7 +128,7 @@ func TestJaegerMarshalerDebugCureSpans(t *testing.T) {
 			},
 		},
 		{
-			unmarshaler: jaegerMarshalerDebug{
+			unmarshaler: jaegerMarshalerCurer{
 				marshaler: jaegerJSONSpanMarshaler{
 					pbMarshaler: &jsonpb.Marshaler{},
 				},
@@ -144,7 +144,7 @@ func TestJaegerMarshalerDebugCureSpans(t *testing.T) {
 			},
 		},
 		{
-			unmarshaler: jaegerMarshalerDebug{
+			unmarshaler: jaegerMarshalerCurer{
 				marshaler:             jaegerProtoSpanMarshaler{},
 				version:               sarama.V2_0_0_0,
 				maxMessageBytes:       maxMessageBytes,
@@ -159,7 +159,7 @@ func TestJaegerMarshalerDebugCureSpans(t *testing.T) {
 			},
 		},
 		{
-			unmarshaler: jaegerMarshalerDebug{
+			unmarshaler: jaegerMarshalerCurer{
 				marshaler:             jaegerProtoSpanMarshaler{},
 				version:               sarama.V2_0_0_0,
 				maxMessageBytes:       maxMessageBytes,
@@ -183,8 +183,8 @@ func TestJaegerMarshalerDebugCureSpans(t *testing.T) {
 	}
 }
 
-func TestJaegerMarshalerDebug_error_covert_traceID(t *testing.T) {
-	marshaler := jaegerMarshalerDebug{
+func TestJaegerMarshalerCurer_error_covert_traceID(t *testing.T) {
+	marshaler := jaegerMarshalerCurer{
 		marshaler: jaegerProtoSpanMarshaler{},
 	}
 	td := pdata.NewTraces()
@@ -314,7 +314,7 @@ func TestCureSpans(t *testing.T) {
 
 	marshaler := jaegerProtoSpanMarshaler{}
 
-	j := jaegerMarshalerDebug{
+	j := jaegerMarshalerCurer{
 		marshaler:             jaegerProtoSpanMarshaler{},
 		version:               sarama.V2_0_0_0,
 		maxMessageBytes:       maxMessageBytes,
@@ -334,7 +334,7 @@ func TestCureSpans(t *testing.T) {
 	}
 }
 
-func TestJaegerMarshalerDebugCureSpansFail(t *testing.T) {
+func TestJaegerMarshalerCurerCureSpansFail(t *testing.T) {
 	maxMessageBytes := 1024
 	maxAttributeValueSize := 256
 
@@ -350,7 +350,7 @@ func TestJaegerMarshalerDebugCureSpansFail(t *testing.T) {
 	}
 	span.Tags = tags
 
-	j := jaegerMarshalerDebug{
+	j := jaegerMarshalerCurer{
 		marshaler:             jaegerProtoSpanMarshaler{},
 		version:               sarama.V2_0_0_0,
 		maxMessageBytes:       maxMessageBytes,

--- a/exporter/kafkaexporter/jaeger_marshaler_debug.go
+++ b/exporter/kafkaexporter/jaeger_marshaler_debug.go
@@ -19,15 +19,18 @@ import (
 )
 
 const (
-	maximumRecordOverhead   = 5*binary.MaxVarintLen32 + binary.MaxVarintLen64 + 1
-	producerMessageOverhead = 26 // the metadata overhead of CRC, flags, etc.
+	maximumRecordOverhead        = 5*binary.MaxVarintLen32 + binary.MaxVarintLen64 + 1
+	producerMessageOverhead      = 26 // the metadata overhead of CRC, flags, etc.
+	defaultMaxAttributeValueSize = 131072
 )
 
 type jaegerMarshalerDebug struct {
-	marshaler          jaegerSpanMarshaler
-	version            sarama.KafkaVersion
-	maxMessageBytes    int
-	dumpSpanAttributes bool
+	marshaler             jaegerSpanMarshaler
+	version               sarama.KafkaVersion
+	maxMessageBytes       int
+	dumpSpanAttributes    bool
+	maxAttributeValueSize int
+	cureSpans             bool
 }
 
 var _ TracesMarshaler = (*jaegerMarshalerDebug)(nil)
@@ -62,6 +65,16 @@ func (j jaegerMarshalerDebug) Marshal(traces pdata.Traces, topic string) ([]*sar
 				// We log instead of throwing an error since the caller for this tracesPusher() will return an error and not even
 				// send those messages that didn't exceed the max message size.
 				log.Printf("span exceeds max message size: %d vs %d. span%s\n", messageSize, j.maxMessageBytes, j.spanAsString(span))
+				// If cure spans is configured, we will attempt to fix the large span by truncating the large tag values.
+				if j.cureSpans {
+					log.Printf("will attempt to cure span")
+					msg, err = j.cureSpan(span, topic)
+					// continue to process spans if an error occured while curing the span
+					if err != nil {
+						errs = multierr.Append(errs, err)
+						continue
+					}
+				}
 			}
 			messages = append(messages, msg)
 		}
@@ -113,6 +126,62 @@ func (j jaegerMarshalerDebug) spanAsString(span *jaegerproto.Span) string {
 	return sb.String()
 }
 
+func (j jaegerMarshalerDebug) cureSpan(span *jaegerproto.Span, topic string) (*sarama.ProducerMessage, error) {
+	// Go through the attributes and get the indices of tags whose values exceed j.maxAttributeValueSize
+	var indices []int
+	for i, kv := range span.Tags {
+		if kv.VType == jaegerproto.ValueType_STRING {
+			if len(kv.GetVStr()) > j.maxAttributeValueSize {
+				indices = append(indices, i)
+			}
+		} else if kv.VType == jaegerproto.ValueType_BINARY {
+			if len(kv.GetVBinary()) > j.maxAttributeValueSize {
+				indices = append(indices, i)
+			}
+		}
+	}
+
+	// For the attribute indices we got, look through and truncate them in the span.Tags
+	var truncatedKeys []string
+	for _, i := range indices {
+		kv := span.Tags[i]
+		if kv.VType == jaegerproto.ValueType_STRING {
+			kv.VStr = kv.VStr[:j.maxAttributeValueSize]
+		} else if kv.VType == jaegerproto.ValueType_BINARY {
+			kv.VBinary = kv.VBinary[:j.maxAttributeValueSize]
+		}
+		// replace the kv in the slice with one whose value is truncated.
+		span.Tags[i] = kv
+		truncatedKeys = append(truncatedKeys, kv.Key+".truncated")
+	}
+
+	// append the ".truncated" attributes to the span list.
+	for _, k := range truncatedKeys {
+		kv := jaegerproto.KeyValue{
+			Key:   k,
+			VType: jaegerproto.ValueType_BOOL,
+			VBool: true,
+		}
+		span.Tags = append(span.Tags, kv)
+	}
+
+	bts, err := j.marshaler.marshal(span)
+	// return err if there is a problem marshaling
+	if err != nil {
+		return nil, err
+	}
+	key := []byte(span.TraceID.String())
+	msg := &sarama.ProducerMessage{
+		Topic: topic,
+		Value: sarama.ByteEncoder(bts),
+		Key:   sarama.ByteEncoder(key),
+	}
+	// Computed the same way as in https://github.com/Shopify/sarama/blob/a060ecaa8887587485754af088bd8a521f6d55e9/async_producer.go#L233
+	//messageSize := byteSize(msg, j.version)
+	return msg, nil
+	//return span, nil
+}
+
 func valueToString(kv jaegerproto.KeyValue) string {
 	if kv.VType == jaegerproto.ValueType_STRING {
 		return kv.GetVStr()
@@ -145,6 +214,9 @@ func valueSize(kv jaegerproto.KeyValue) int {
 	}
 }
 
+// byteSize computes the kafka message size.
+// Computed the same way as in https://github.com/Shopify/sarama/blob/a060ecaa8887587485754af088bd8a521f6d55e9/async_producer.go#L233
+// For updates check the function in the sarama package whenever it changes.
 func byteSize(m *sarama.ProducerMessage, v sarama.KafkaVersion) int {
 	var size int
 	if v.IsAtLeast(sarama.V0_11_0_0) {

--- a/exporter/kafkaexporter/jaeger_marshaler_debug_test.go
+++ b/exporter/kafkaexporter/jaeger_marshaler_debug_test.go
@@ -2,11 +2,13 @@ package kafkaexporter
 
 import (
 	"bytes"
+	//"fmt"
 	"strings"
 	"testing"
 
 	"github.com/Shopify/sarama"
 	"github.com/gogo/protobuf/jsonpb"
+	jaegerproto "github.com/jaegertracing/jaeger/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/model/pdata"
@@ -31,12 +33,12 @@ func TestJaegerMarshalerDebug(t *testing.T) {
 	span.Attributes().Insert("tag1", pdata.NewAttributeValueString("tag1-val"))
 
 	// Create a string whose size is maxMessageBytes
-	var b strings.Builder
-	b.Grow(maxMessageBytes)
-	for i := 0; i < maxMessageBytes; i++ {
-		b.WriteString("a")
-	}
-	s := b.String()
+	// var b strings.Builder
+	// b.Grow(maxMessageBytes)
+	// for i := 0; i < maxMessageBytes; i++ {
+	// 	b.WriteString("a")
+	// }
+	// s := b.String()
 
 	// Will log on this span that exceeds max message size.
 	span = ils.Spans().AppendEmpty()
@@ -46,7 +48,7 @@ func TestJaegerMarshalerDebug(t *testing.T) {
 	span.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
 	span.SetSpanID(pdata.NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
 	span.Attributes().Insert("tag10", pdata.NewAttributeValueString("tag10-val"))
-	span.Attributes().Insert("big-tag", pdata.NewAttributeValueString(s))
+	span.Attributes().Insert("big-tag", pdata.NewAttributeValueString(createLongString(maxMessageBytes, "a")))
 
 	batches, err := jaegertranslator.InternalTracesToJaegerProto(td)
 	require.NoError(t, err)
@@ -133,4 +135,306 @@ func TestJaegerMarshalerDebug_error_covert_traceID(t *testing.T) {
 	messages, err := marshaler.Marshal(td, "topic")
 	require.Error(t, err)
 	assert.Nil(t, messages)
+}
+
+func TestCureSpans(t *testing.T) {
+	maxMessageBytes := 1024
+	maxAttributeValueSize := 256
+	// td := pdata.NewTraces()
+	// rs := td.ResourceSpans().AppendEmpty()
+	// rs.Resource().Attributes().Insert("test-key", pdata.NewAttributeValueString("test-val"))
+	// ils := rs.InstrumentationLibrarySpans().AppendEmpty()
+
+	// // Will add this span to the messages queue to export
+	// span := ils.Spans().AppendEmpty()
+	// span.SetName("foo")
+	// span.SetStartTimestamp(pdata.Timestamp(10))
+	// span.SetEndTimestamp(pdata.Timestamp(20))
+	// span.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+	// span.SetSpanID(pdata.NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+	// span.Attributes().Insert("tag1", pdata.NewAttributeValueString("tag1-val"))
+
+	// // Create a string whose size is maxMessageBytes
+	// var b strings.Builder
+	// b.Grow(maxMessageBytes)
+	// for i := 0; i < maxMessageBytes; i++ {
+	// 	b.WriteString("a")
+	// }
+	// s := b.String()
+
+	// // Will log on this span that exceeds max message size.
+	// span = ils.Spans().AppendEmpty()
+	// span.SetName("bar")
+	// span.SetStartTimestamp(pdata.Timestamp(100))
+	// span.SetEndTimestamp(pdata.Timestamp(225))
+	// span.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+	// span.SetSpanID(pdata.NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+	// span.Attributes().Insert("tag10", pdata.NewAttributeValueString("tag10-val"))
+	// span.Attributes().Insert("big-tag", pdata.NewAttributeValueString(s))
+
+	jaegerSpan := &jaegerproto.Span{
+		TraceID: jaegerproto.TraceID{Low: 100, High: 2000},
+		SpanID:  123,
+		Tags: []jaegerproto.KeyValue{
+			{Key: "tag-1", VType: jaegerproto.ValueType_STRING, VStr: "simple string"},
+			{Key: "tag-2", VType: jaegerproto.ValueType_STRING, VStr: createLongString(128, "fo")},
+			{Key: "tag-3", VType: jaegerproto.ValueType_BOOL, VBool: true},
+			{Key: "tag-4", VType: jaegerproto.ValueType_BINARY, VBinary: createLongByteArray(500)},
+			{Key: "tag-5", VType: jaegerproto.ValueType_STRING, VStr: createLongString(256, "ba")},
+		},
+	}
+
+	expectedJaegerSpan := &jaegerproto.Span{
+		TraceID: jaegerproto.TraceID{Low: 100, High: 2000},
+		SpanID:  123,
+		Tags: []jaegerproto.KeyValue{
+			{Key: "tag-1", VType: jaegerproto.ValueType_STRING, VStr: "simple string"},
+			{Key: "tag-2", VType: jaegerproto.ValueType_STRING, VStr: createLongString(128, "fo")},
+			{Key: "tag-3", VType: jaegerproto.ValueType_BOOL, VBool: true},
+			{Key: "tag-4", VType: jaegerproto.ValueType_BINARY, VBinary: createLongByteArray(256)},
+			{Key: "tag-5", VType: jaegerproto.ValueType_STRING, VStr: createLongString(128, "ba")},
+			{Key: "tag-4.truncated", VType: jaegerproto.ValueType_BOOL, VBool: true},
+			{Key: "tag-5.truncated", VType: jaegerproto.ValueType_BOOL, VBool: true},
+		},
+	}
+
+	marshaler := jaegerProtoSpanMarshaler{}
+	expectedMsgBytes, err := marshaler.marshal(expectedJaegerSpan)
+	require.NoError(t, err)
+	expectedMsgBytesEncoder := sarama.ByteEncoder(expectedMsgBytes)
+
+	j := jaegerMarshalerDebug{
+		marshaler:             marshaler,
+		version:               sarama.V2_0_0_0,
+		maxMessageBytes:       maxMessageBytes,
+		maxAttributeValueSize: maxAttributeValueSize,
+		cureSpans:             true,
+	}
+
+	msg, err := j.cureSpan(jaegerSpan, "test-topic")
+	require.NoError(t, err)
+	assert.Equal(t, expectedMsgBytesEncoder, msg.Value)
+
+	// batches, err := jaegertranslator.InternalTracesToJaegerProto(td)
+	// require.NoError(t, err)
+
+	// //jsonMarshaler := &jsonpb.Marshaler{}
+
+	// batches[0].Spans[0].Process = batches[0].Process
+	// jaegerProtoBytes0, err := batches[0].Spans[0].Marshal()
+	// messageKey := []byte(batches[0].Spans[0].TraceID.String())
+	// require.NoError(t, err)
+	// require.NotNil(t, jaegerProtoBytes0)
+
+	// batches[0].Spans[1].Process = batches[0].Process
+	// // jaegerProtoBytes1, err := batches[0].Spans[1].Marshal()
+	// // require.NoError(t, err)
+	// // require.NotNil(t, jaegerProtoBytes1)
+
+	// j := jaegerMarshalerDebug{
+	// 	marshaler:             jaegerProtoSpanMarshaler{},
+	// 	version:               sarama.V2_0_0_0,
+	// 	maxMessageBytes:       maxMessageBytes,
+	// 	maxAttributeValueSize: maxAttributeValueSize,
+	// 	dumpSpanAttributes:    true,
+	// }
+
+	// fmt.Printf("span 0: %s\n", j.spanAsString(batches[0].Spans[0]))
+	// fmt.Printf("span 1: %s\n", j.spanAsString(batches[0].Spans[1]))
+	// fmt.Println("curing")
+	// curedSpan0, err := j.cureSpan(batches[0].Spans[0], "foo")
+	// require.NoError(t, err)
+	// curedSpan1, err := j.cureSpan(batches[0].Spans[1], "foo")
+	// require.NoError(t, err)
+
+	// fmt.Printf("cured span 0: %s\n", j.spanAsString(curedSpan0))
+	// fmt.Printf("cured span 1: %s\n", j.spanAsString(curedSpan1))
+	// fmt.Println("done")
+
+	// tests := []struct {
+	// 	unmarshaler TracesMarshaler
+	// 	encoding    string
+	// 	messages    []*sarama.ProducerMessage
+	// }{
+	// 	{
+	// 		unmarshaler: jaegerMarshalerDebug{
+	// 			marshaler:       jaegerProtoSpanMarshaler{},
+	// 			version:         sarama.V2_0_0_0,
+	// 			maxMessageBytes: maxMessageBytes,
+	// 		},
+	// 		encoding: "jaeger_proto",
+	// 		messages: []*sarama.ProducerMessage{
+	// 			{Topic: "topic", Value: sarama.ByteEncoder(jaegerProtoBytes0), Key: sarama.ByteEncoder(messageKey)},
+	// 			{Topic: "topic", Value: sarama.ByteEncoder(jaegerProtoBytes1), Key: sarama.ByteEncoder(messageKey)}},
+	// 	},
+	// 	{}
+	// }
+}
+
+func TestJaegerMarshalerDebugCureSpans(t *testing.T) {
+	maxMessageBytes := 1024
+	maxAttributeValueSize := 256
+	td := pdata.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().Insert("test-key", pdata.NewAttributeValueString("test-val"))
+	ils := rs.InstrumentationLibrarySpans().AppendEmpty()
+
+	// Will add this span to the messages queue to export
+	span := ils.Spans().AppendEmpty()
+	span.SetName("foo")
+	span.SetStartTimestamp(pdata.Timestamp(10))
+	span.SetEndTimestamp(pdata.Timestamp(20))
+	span.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+	span.SetSpanID(pdata.NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+	span.Attributes().Insert("tag1", pdata.NewAttributeValueString("tag1-val"))
+
+	// Create a string whose size is maxMessageBytes
+	// var b strings.Builder
+	// b.Grow(maxMessageBytes)
+	// for i := 0; i < maxMessageBytes; i++ {
+	// 	b.WriteString("a")
+	// }
+	// s := b.String()
+
+	// Will log on this span that exceeds max message size.
+	span = ils.Spans().AppendEmpty()
+	span.SetName("bar")
+	span.SetStartTimestamp(pdata.Timestamp(100))
+	span.SetEndTimestamp(pdata.Timestamp(225))
+	span.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+	span.SetSpanID(pdata.NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+	span.Attributes().Insert("tag10", pdata.NewAttributeValueString("tag10-val"))
+	span.Attributes().Insert("big-tag", pdata.NewAttributeValueString(createLongString(maxMessageBytes, "a")))
+
+	// cured spans
+	curedTd := pdata.NewTraces()
+	curedRs := curedTd.ResourceSpans().AppendEmpty()
+	curedRs.Resource().Attributes().Insert("test-key", pdata.NewAttributeValueString("test-val"))
+	curedIls := curedRs.InstrumentationLibrarySpans().AppendEmpty()
+
+	// Create a string whose size is maxAttributeValueSize
+	// var b1 strings.Builder
+	// b1.Grow(maxAttributeValueSize)
+	// for i := 0; i < maxAttributeValueSize; i++ {
+	// 	b1.WriteString("a")
+	// }
+	//s1 := b1.String()
+
+	curedSpan := curedIls.Spans().AppendEmpty()
+	curedSpan.SetName("bar")
+	curedSpan.SetStartTimestamp(pdata.Timestamp(100))
+	curedSpan.SetEndTimestamp(pdata.Timestamp(225))
+	curedSpan.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+	curedSpan.SetSpanID(pdata.NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+	curedSpan.Attributes().Insert("tag10", pdata.NewAttributeValueString("tag10-val"))
+	curedSpan.Attributes().Insert("big-tag", pdata.NewAttributeValueString(createLongString(maxAttributeValueSize, "a")))
+	curedSpan.Attributes().Insert("big-tag.truncated", pdata.NewAttributeValueBool(true))
+
+	batches, err := jaegertranslator.InternalTracesToJaegerProto(td)
+	require.NoError(t, err)
+
+	curedBatches, err := jaegertranslator.InternalTracesToJaegerProto(curedTd)
+	require.NoError(t, err)
+
+	jsonMarshaler := &jsonpb.Marshaler{}
+
+	batches[0].Spans[0].Process = batches[0].Process
+	jaegerProtoBytes0, err := batches[0].Spans[0].Marshal()
+	messageKey := []byte(batches[0].Spans[0].TraceID.String())
+	require.NoError(t, err)
+	require.NotNil(t, jaegerProtoBytes0)
+
+	jsonByteBuffer0 := new(bytes.Buffer)
+	require.NoError(t, jsonMarshaler.Marshal(jsonByteBuffer0, batches[0].Spans[0]))
+
+	batches[0].Spans[1].Process = batches[0].Process
+	jaegerProtoBytes1, err := batches[0].Spans[1].Marshal()
+	require.NoError(t, err)
+	require.NotNil(t, jaegerProtoBytes1)
+
+	jsonByteBuffer1 := new(bytes.Buffer)
+	require.NoError(t, jsonMarshaler.Marshal(jsonByteBuffer1, batches[0].Spans[1]))
+
+	curedBatches[0].Spans[0].Process = curedBatches[0].Process
+	curedJaegerProtoBytes1, err := curedBatches[0].Spans[0].Marshal()
+	require.NoError(t, err)
+	require.NotNil(t, curedJaegerProtoBytes1)
+
+	curedJsonByteBuffer1 := new(bytes.Buffer)
+	require.NoError(t, jsonMarshaler.Marshal(curedJsonByteBuffer1, curedBatches[0].Spans[0]))
+
+	tests := []struct {
+		unmarshaler TracesMarshaler
+		encoding    string
+		messages    []*sarama.ProducerMessage
+	}{
+		{
+			unmarshaler: jaegerMarshalerDebug{
+				marshaler:             jaegerProtoSpanMarshaler{},
+				version:               sarama.V2_0_0_0,
+				maxMessageBytes:       maxMessageBytes,
+				maxAttributeValueSize: maxAttributeValueSize,
+				cureSpans:             true,
+			},
+			encoding: "jaeger_proto",
+			messages: []*sarama.ProducerMessage{
+				{Topic: "topic", Value: sarama.ByteEncoder(jaegerProtoBytes0), Key: sarama.ByteEncoder(messageKey)},
+				{Topic: "topic", Value: sarama.ByteEncoder(curedJaegerProtoBytes1), Key: sarama.ByteEncoder(messageKey)}},
+		},
+		{
+			unmarshaler: jaegerMarshalerDebug{
+				marshaler: jaegerJSONSpanMarshaler{
+					pbMarshaler: &jsonpb.Marshaler{},
+				},
+				version:               sarama.V2_0_0_0,
+				maxMessageBytes:       maxMessageBytes,
+				maxAttributeValueSize: maxAttributeValueSize,
+				cureSpans:             true,
+			},
+			encoding: "jaeger_json",
+			messages: []*sarama.ProducerMessage{
+				{Topic: "topic", Value: sarama.ByteEncoder(jsonByteBuffer0.Bytes()), Key: sarama.ByteEncoder(messageKey)},
+				{Topic: "topic", Value: sarama.ByteEncoder(curedJsonByteBuffer1.Bytes()), Key: sarama.ByteEncoder(messageKey)},
+			},
+		},
+		{
+			unmarshaler: jaegerMarshalerDebug{
+				marshaler:             jaegerProtoSpanMarshaler{},
+				version:               sarama.V2_0_0_0,
+				maxMessageBytes:       maxMessageBytes,
+				maxAttributeValueSize: maxAttributeValueSize,
+				dumpSpanAttributes:    true, // test setting this to true
+				cureSpans:             true,
+			},
+			encoding: "jaeger_proto",
+			messages: []*sarama.ProducerMessage{
+				{Topic: "topic", Value: sarama.ByteEncoder(jaegerProtoBytes0), Key: sarama.ByteEncoder(messageKey)},
+				{Topic: "topic", Value: sarama.ByteEncoder(curedJaegerProtoBytes1), Key: sarama.ByteEncoder(messageKey)}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.encoding, func(t *testing.T) {
+			messages, err := test.unmarshaler.Marshal(td, "topic")
+			require.NoError(t, err)
+			assert.Equal(t, test.messages, messages)
+			assert.Equal(t, test.encoding, test.unmarshaler.Encoding())
+		})
+	}
+}
+
+func createLongString(n int, s string) string {
+	var b strings.Builder
+	b.Grow(n * len(s))
+	for i := 0; i < n; i++ {
+		b.WriteString(s)
+	}
+	return b.String()
+}
+
+func createLongByteArray(n int) []byte {
+	arr := make([]byte, n, n)
+	for i := 0; i < n; i++ {
+		arr[i] = byte(i % 10)
+	}
+	return arr
 }

--- a/exporter/kafkaexporter/jaeger_marshaler_debug_test.go
+++ b/exporter/kafkaexporter/jaeger_marshaler_debug_test.go
@@ -2,6 +2,7 @@ package kafkaexporter
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -15,8 +16,11 @@ import (
 	jaegertranslator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
 )
 
-func TestJaegerMarshalerDebug(t *testing.T) {
+func TestJaegerMarshalerDebugCureSpans(t *testing.T) {
 	maxMessageBytes := 1024
+	maxAttributeValueSize := 256
+	jsonMarshaler := &jsonpb.Marshaler{}
+
 	td := pdata.NewTraces()
 	rs := td.ResourceSpans().AppendEmpty()
 	rs.Resource().Attributes().Insert("test-key", pdata.NewAttributeValueString("test-val"))
@@ -31,7 +35,7 @@ func TestJaegerMarshalerDebug(t *testing.T) {
 	span.SetSpanID(pdata.NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
 	span.Attributes().Insert("tag1", pdata.NewAttributeValueString("tag1-val"))
 
-	// Will log on this span that exceeds max message size.
+	// Will cure this span
 	span = ils.Spans().AppendEmpty()
 	span.SetName("bar")
 	span.SetStartTimestamp(pdata.Timestamp(100))
@@ -41,10 +45,21 @@ func TestJaegerMarshalerDebug(t *testing.T) {
 	span.Attributes().Insert("tag10", pdata.NewAttributeValueString("tag10-val"))
 	span.Attributes().Insert("big-tag", pdata.NewAttributeValueString(createLongString(maxMessageBytes, "a")))
 
+	// Will be unable to cure this span. Depending on the test config, will drop it or not.
+	span = ils.Spans().AppendEmpty()
+	span.SetName("buzz")
+	span.SetStartTimestamp(pdata.Timestamp(100))
+	span.SetEndTimestamp(pdata.Timestamp(225))
+	span.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+	span.SetSpanID(pdata.NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+	span.Attributes().Insert("tag10", pdata.NewAttributeValueString("tag10-val"))
+	for i := 0; i < 64; i++ {
+		span.Attributes().Insert(fmt.Sprintf("big-tag-%d", i), pdata.NewAttributeValueString(createLongString(maxMessageBytes, "a")))
+	}
+	span.Attributes().Insert("big-tag", pdata.NewAttributeValueString(createLongString(maxMessageBytes, "a")))
+
 	batches, err := jaegertranslator.InternalTracesToJaegerProto(td)
 	require.NoError(t, err)
-
-	jsonMarshaler := &jsonpb.Marshaler{}
 
 	batches[0].Spans[0].Process = batches[0].Process
 	jaegerProtoBytes0, err := batches[0].Spans[0].Marshal()
@@ -55,13 +70,43 @@ func TestJaegerMarshalerDebug(t *testing.T) {
 	jsonByteBuffer0 := new(bytes.Buffer)
 	require.NoError(t, jsonMarshaler.Marshal(jsonByteBuffer0, batches[0].Spans[0]))
 
-	batches[0].Spans[1].Process = batches[0].Process
-	jaegerProtoBytes1, err := batches[0].Spans[1].Marshal()
+	// Get the marshalled bytes of the 2nd span that cannot be cured. Will be the needed for expected value of the tests
+	// depending on whether dropSpans is turned on or not.
+	batches[0].Spans[2].Process = batches[0].Process
+	jaegerProtoBytes2, err := batches[0].Spans[2].Marshal()
 	require.NoError(t, err)
-	require.NotNil(t, jaegerProtoBytes1)
+	require.NotNil(t, jaegerProtoBytes2)
 
-	jsonByteBuffer1 := new(bytes.Buffer)
-	require.NoError(t, jsonMarshaler.Marshal(jsonByteBuffer1, batches[0].Spans[1]))
+	jsonByteBuffer2 := new(bytes.Buffer)
+	require.NoError(t, jsonMarshaler.Marshal(jsonByteBuffer2, batches[0].Spans[2]))
+
+	// expected cured spans should be similar to spans that came in as if they were already cured.
+	// batches[0].Spans[1] when cured will be the same as curedBatches[0].Spans[0]
+	curedTd := pdata.NewTraces()
+	curedRs := curedTd.ResourceSpans().AppendEmpty()
+	curedRs.Resource().Attributes().Insert("test-key", pdata.NewAttributeValueString("test-val"))
+	curedIls := curedRs.InstrumentationLibrarySpans().AppendEmpty()
+
+	curedSpan := curedIls.Spans().AppendEmpty()
+	curedSpan.SetName("bar")
+	curedSpan.SetStartTimestamp(pdata.Timestamp(100))
+	curedSpan.SetEndTimestamp(pdata.Timestamp(225))
+	curedSpan.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+	curedSpan.SetSpanID(pdata.NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+	curedSpan.Attributes().Insert("tag10", pdata.NewAttributeValueString("tag10-val"))
+	curedSpan.Attributes().Insert("big-tag", pdata.NewAttributeValueString(createLongString(maxAttributeValueSize, "a")))
+	curedSpan.Attributes().Insert("big-tag"+truncationTagSuffix, pdata.NewAttributeValueBool(true))
+
+	curedBatches, err := jaegertranslator.InternalTracesToJaegerProto(curedTd)
+	require.NoError(t, err)
+
+	curedBatches[0].Spans[0].Process = curedBatches[0].Process
+	curedJaegerProtoBytes1, err := curedBatches[0].Spans[0].Marshal()
+	require.NoError(t, err)
+	require.NotNil(t, curedJaegerProtoBytes1)
+
+	curedJsonByteBuffer1 := new(bytes.Buffer)
+	require.NoError(t, jsonMarshaler.Marshal(curedJsonByteBuffer1, curedBatches[0].Spans[0]))
 
 	tests := []struct {
 		unmarshaler TracesMarshaler
@@ -70,40 +115,62 @@ func TestJaegerMarshalerDebug(t *testing.T) {
 	}{
 		{
 			unmarshaler: jaegerMarshalerDebug{
-				marshaler:       jaegerProtoSpanMarshaler{},
-				version:         sarama.V2_0_0_0,
-				maxMessageBytes: maxMessageBytes,
+				marshaler:             jaegerProtoSpanMarshaler{},
+				version:               sarama.V2_0_0_0,
+				maxMessageBytes:       maxMessageBytes,
+				maxAttributeValueSize: maxAttributeValueSize,
 			},
 			encoding: "jaeger_proto",
 			messages: []*sarama.ProducerMessage{
 				{Topic: "topic", Value: sarama.ByteEncoder(jaegerProtoBytes0), Key: sarama.ByteEncoder(messageKey)},
-				{Topic: "topic", Value: sarama.ByteEncoder(jaegerProtoBytes1), Key: sarama.ByteEncoder(messageKey)}},
+				{Topic: "topic", Value: sarama.ByteEncoder(curedJaegerProtoBytes1), Key: sarama.ByteEncoder(messageKey)},
+				{Topic: "topic", Value: sarama.ByteEncoder(jaegerProtoBytes2), Key: sarama.ByteEncoder(messageKey)},
+			},
 		},
 		{
 			unmarshaler: jaegerMarshalerDebug{
 				marshaler: jaegerJSONSpanMarshaler{
 					pbMarshaler: &jsonpb.Marshaler{},
 				},
-				version:         sarama.V2_0_0_0,
-				maxMessageBytes: maxMessageBytes,
+				version:               sarama.V2_0_0_0,
+				maxMessageBytes:       maxMessageBytes,
+				maxAttributeValueSize: maxAttributeValueSize,
 			},
 			encoding: "jaeger_json",
 			messages: []*sarama.ProducerMessage{
 				{Topic: "topic", Value: sarama.ByteEncoder(jsonByteBuffer0.Bytes()), Key: sarama.ByteEncoder(messageKey)},
-				{Topic: "topic", Value: sarama.ByteEncoder(jsonByteBuffer1.Bytes()), Key: sarama.ByteEncoder(messageKey)},
+				{Topic: "topic", Value: sarama.ByteEncoder(curedJsonByteBuffer1.Bytes()), Key: sarama.ByteEncoder(messageKey)},
+				{Topic: "topic", Value: sarama.ByteEncoder(jsonByteBuffer2.Bytes()), Key: sarama.ByteEncoder(messageKey)},
 			},
 		},
 		{
 			unmarshaler: jaegerMarshalerDebug{
-				marshaler:          jaegerProtoSpanMarshaler{},
-				version:            sarama.V2_0_0_0,
-				maxMessageBytes:    maxMessageBytes,
-				dumpSpanAttributes: true, // test setting this to true
+				marshaler:             jaegerProtoSpanMarshaler{},
+				version:               sarama.V2_0_0_0,
+				maxMessageBytes:       maxMessageBytes,
+				maxAttributeValueSize: maxAttributeValueSize,
+				dumpSpanAttributes:    true, // test setting this to true
 			},
 			encoding: "jaeger_proto",
 			messages: []*sarama.ProducerMessage{
 				{Topic: "topic", Value: sarama.ByteEncoder(jaegerProtoBytes0), Key: sarama.ByteEncoder(messageKey)},
-				{Topic: "topic", Value: sarama.ByteEncoder(jaegerProtoBytes1), Key: sarama.ByteEncoder(messageKey)}},
+				{Topic: "topic", Value: sarama.ByteEncoder(curedJaegerProtoBytes1), Key: sarama.ByteEncoder(messageKey)},
+				{Topic: "topic", Value: sarama.ByteEncoder(jaegerProtoBytes2), Key: sarama.ByteEncoder(messageKey)},
+			},
+		},
+		{
+			unmarshaler: jaegerMarshalerDebug{
+				marshaler:             jaegerProtoSpanMarshaler{},
+				version:               sarama.V2_0_0_0,
+				maxMessageBytes:       maxMessageBytes,
+				maxAttributeValueSize: maxAttributeValueSize,
+				dropSpans:             true, // Test that the 3rd span is dropped since it cannot be cured
+			},
+			encoding: "jaeger_proto",
+			messages: []*sarama.ProducerMessage{
+				{Topic: "topic", Value: sarama.ByteEncoder(jaegerProtoBytes0), Key: sarama.ByteEncoder(messageKey)},
+				{Topic: "topic", Value: sarama.ByteEncoder(curedJaegerProtoBytes1), Key: sarama.ByteEncoder(messageKey)},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -141,7 +208,7 @@ func TestCureSpans(t *testing.T) {
 				TraceID: jaegerproto.TraceID{Low: 101, High: 2001},
 				SpanID:  124,
 				Tags: []jaegerproto.KeyValue{
-					{Key: "tag-1", VType: jaegerproto.ValueType_STRING, VStr: "simple string"},
+					{Key: "tag-1", VType: jaegerproto.ValueType_STRING, VStr: "simple"},
 					{Key: "tag-2", VType: jaegerproto.ValueType_STRING, VStr: createLongString(32, "fo")},
 					{Key: "tag-3", VType: jaegerproto.ValueType_BOOL, VBool: true},
 					{Key: "tag-4", VType: jaegerproto.ValueType_BINARY, VBinary: createLongByteArray(50)},
@@ -152,7 +219,7 @@ func TestCureSpans(t *testing.T) {
 				TraceID: jaegerproto.TraceID{Low: 101, High: 2001},
 				SpanID:  124,
 				Tags: []jaegerproto.KeyValue{
-					{Key: "tag-1", VType: jaegerproto.ValueType_STRING, VStr: "simple string"},
+					{Key: "tag-1", VType: jaegerproto.ValueType_STRING, VStr: "simple"},
 					{Key: "tag-2", VType: jaegerproto.ValueType_STRING, VStr: createLongString(32, "fo")},
 					{Key: "tag-3", VType: jaegerproto.ValueType_BOOL, VBool: true},
 					{Key: "tag-4", VType: jaegerproto.ValueType_BINARY, VBinary: createLongByteArray(50)},
@@ -165,7 +232,7 @@ func TestCureSpans(t *testing.T) {
 				TraceID: jaegerproto.TraceID{Low: 100, High: 2000},
 				SpanID:  123,
 				Tags: []jaegerproto.KeyValue{
-					{Key: "tag-1", VType: jaegerproto.ValueType_STRING, VStr: "simple string"},
+					{Key: "tag-1", VType: jaegerproto.ValueType_STRING, VStr: "simple"},
 					{Key: "tag-2", VType: jaegerproto.ValueType_STRING, VStr: createLongString(128, "fo")},
 					{Key: "tag-3", VType: jaegerproto.ValueType_BOOL, VBool: true},
 					{Key: "tag-4", VType: jaegerproto.ValueType_BINARY, VBinary: createLongByteArray(500)},
@@ -176,13 +243,13 @@ func TestCureSpans(t *testing.T) {
 				TraceID: jaegerproto.TraceID{Low: 100, High: 2000},
 				SpanID:  123,
 				Tags: []jaegerproto.KeyValue{
-					{Key: "tag-1", VType: jaegerproto.ValueType_STRING, VStr: "simple string"},
+					{Key: "tag-1", VType: jaegerproto.ValueType_STRING, VStr: "simple"},
 					{Key: "tag-2", VType: jaegerproto.ValueType_STRING, VStr: createLongString(128, "fo")},
 					{Key: "tag-3", VType: jaegerproto.ValueType_BOOL, VBool: true},
 					{Key: "tag-4", VType: jaegerproto.ValueType_BINARY, VBinary: createLongByteArray(256)},
 					{Key: "tag-5", VType: jaegerproto.ValueType_STRING, VStr: createLongString(128, "ba")},
-					{Key: "tag-4.truncated", VType: jaegerproto.ValueType_BOOL, VBool: true},
-					{Key: "tag-5.truncated", VType: jaegerproto.ValueType_BOOL, VBool: true},
+					{Key: "tag-4" + truncationTagSuffix, VType: jaegerproto.ValueType_BOOL, VBool: true},
+					{Key: "tag-5" + truncationTagSuffix, VType: jaegerproto.ValueType_BOOL, VBool: true},
 				},
 			},
 		},
@@ -191,7 +258,7 @@ func TestCureSpans(t *testing.T) {
 				TraceID: jaegerproto.TraceID{Low: 102, High: 2002},
 				SpanID:  125,
 				Tags: []jaegerproto.KeyValue{
-					{Key: "tag-1", VType: jaegerproto.ValueType_STRING, VStr: "simple string"},
+					{Key: "tag-1", VType: jaegerproto.ValueType_STRING, VStr: "simple"},
 					{Key: "tag-2", VType: jaegerproto.ValueType_STRING, VStr: createLongString(128, "fo")},
 					{Key: "tag-3", VType: jaegerproto.ValueType_INT64, VInt64: 68},
 					{Key: "tag-4", VType: jaegerproto.ValueType_BINARY, VBinary: createLongByteArray(500)},
@@ -203,16 +270,16 @@ func TestCureSpans(t *testing.T) {
 				TraceID: jaegerproto.TraceID{Low: 102, High: 2002},
 				SpanID:  125,
 				Tags: []jaegerproto.KeyValue{
-					{Key: "tag-1", VType: jaegerproto.ValueType_STRING, VStr: "simple string"},
+					{Key: "tag-1", VType: jaegerproto.ValueType_STRING, VStr: "simple"},
 					{Key: "tag-2", VType: jaegerproto.ValueType_STRING, VStr: createLongString(64, "fo")},
 					{Key: "tag-3", VType: jaegerproto.ValueType_INT64, VInt64: 68},
 					{Key: "tag-4", VType: jaegerproto.ValueType_BINARY, VBinary: createLongByteArray(128)},
 					{Key: "tag-5", VType: jaegerproto.ValueType_STRING, VStr: createLongString(64, "ba")},
 					{Key: "tag-6", VType: jaegerproto.ValueType_STRING, VStr: createLongString(64, "wx")},
-					{Key: "tag-4.truncated", VType: jaegerproto.ValueType_BOOL, VBool: true},
-					{Key: "tag-5.truncated", VType: jaegerproto.ValueType_BOOL, VBool: true},
-					{Key: "tag-6.truncated", VType: jaegerproto.ValueType_BOOL, VBool: true},
-					{Key: "tag-2.truncated", VType: jaegerproto.ValueType_BOOL, VBool: true},
+					{Key: "tag-4" + truncationTagSuffix, VType: jaegerproto.ValueType_BOOL, VBool: true},
+					{Key: "tag-5" + truncationTagSuffix, VType: jaegerproto.ValueType_BOOL, VBool: true},
+					{Key: "tag-6" + truncationTagSuffix, VType: jaegerproto.ValueType_BOOL, VBool: true},
+					{Key: "tag-2" + truncationTagSuffix, VType: jaegerproto.ValueType_BOOL, VBool: true},
 				},
 			},
 		},
@@ -221,28 +288,25 @@ func TestCureSpans(t *testing.T) {
 				TraceID: jaegerproto.TraceID{Low: 103, High: 2003},
 				SpanID:  126,
 				Tags: []jaegerproto.KeyValue{
-					{Key: "tag-1", VType: jaegerproto.ValueType_STRING, VStr: "simple string"},
-					{Key: "tag-2", VType: jaegerproto.ValueType_STRING, VStr: createLongString(128, "fo")},
-					{Key: "tag-3", VType: jaegerproto.ValueType_INT64, VInt64: 68},
-					{Key: "tag-4", VType: jaegerproto.ValueType_BINARY, VBinary: createLongByteArray(500)},
-					{Key: "tag-5", VType: jaegerproto.ValueType_STRING, VStr: createLongString(256, "ba")},
-					{Key: "tag-6", VType: jaegerproto.ValueType_STRING, VStr: createLongString(256, "wx")},
+					{Key: "tag-1", VType: jaegerproto.ValueType_STRING, VStr: "simple"},
+					{Key: "tag-2", VType: jaegerproto.ValueType_STRING, VStr: createLongString(1050, "fo")},
+					{Key: "tag-3", VType: jaegerproto.ValueType_BOOL, VBool: false},
+					{Key: "tag-4", VType: jaegerproto.ValueType_BINARY, VBinary: createLongByteArray(32)},
+					{Key: "tag-5", VType: jaegerproto.ValueType_STRING, VStr: createLongString(10, "ba")},
+					{Key: "tag-6", VType: jaegerproto.ValueType_STRING, VStr: createLongString(10, "wx")},
 				},
 			},
 			expectedSpan: &jaegerproto.Span{
 				TraceID: jaegerproto.TraceID{Low: 103, High: 2003},
 				SpanID:  126,
 				Tags: []jaegerproto.KeyValue{
-					{Key: "tag-1", VType: jaegerproto.ValueType_STRING, VStr: "simple string"},
-					{Key: "tag-2", VType: jaegerproto.ValueType_STRING, VStr: createLongString(64, "fo")},
-					{Key: "tag-3", VType: jaegerproto.ValueType_INT64, VInt64: 68},
-					{Key: "tag-4", VType: jaegerproto.ValueType_BINARY, VBinary: createLongByteArray(128)},
-					{Key: "tag-5", VType: jaegerproto.ValueType_STRING, VStr: createLongString(64, "ba")},
-					{Key: "tag-6", VType: jaegerproto.ValueType_STRING, VStr: createLongString(64, "wx")},
-					{Key: "tag-4.truncated", VType: jaegerproto.ValueType_BOOL, VBool: true},
-					{Key: "tag-5.truncated", VType: jaegerproto.ValueType_BOOL, VBool: true},
-					{Key: "tag-6.truncated", VType: jaegerproto.ValueType_BOOL, VBool: true},
-					{Key: "tag-2.truncated", VType: jaegerproto.ValueType_BOOL, VBool: true},
+					{Key: "tag-1", VType: jaegerproto.ValueType_STRING, VStr: "simple"},
+					{Key: "tag-2", VType: jaegerproto.ValueType_STRING, VStr: createLongString(128, "fo")},
+					{Key: "tag-3", VType: jaegerproto.ValueType_BOOL, VBool: false},
+					{Key: "tag-4", VType: jaegerproto.ValueType_BINARY, VBinary: createLongByteArray(32)},
+					{Key: "tag-5", VType: jaegerproto.ValueType_STRING, VStr: createLongString(10, "ba")},
+					{Key: "tag-6", VType: jaegerproto.ValueType_STRING, VStr: createLongString(10, "wx")},
+					{Key: "tag-2" + truncationTagSuffix, VType: jaegerproto.ValueType_BOOL, VBool: true},
 				},
 			},
 		},
@@ -255,10 +319,11 @@ func TestCureSpans(t *testing.T) {
 		version:               sarama.V2_0_0_0,
 		maxMessageBytes:       maxMessageBytes,
 		maxAttributeValueSize: maxAttributeValueSize,
-		cureSpans:             true,
 	}
 
 	for _, test := range tests {
+		// Sanity test logging the string
+		fmt.Printf("span: %s\n", j.spanAsString(test.inputSpan))
 		msg, err := j.cureSpan(test.inputSpan, "test-topic")
 		require.NoError(t, err)
 
@@ -290,140 +355,11 @@ func TestJaegerMarshalerDebugCureSpansFail(t *testing.T) {
 		version:               sarama.V2_0_0_0,
 		maxMessageBytes:       maxMessageBytes,
 		maxAttributeValueSize: maxAttributeValueSize,
-		cureSpans:             true,
 	}
 
 	msg, err := j.cureSpan(span, "test-topic-2")
 	require.Error(t, err)
 	assert.Nil(t, msg)
-}
-
-func TestJaegerMarshalerDebugCureSpans(t *testing.T) {
-	maxMessageBytes := 1024
-	maxAttributeValueSize := 256
-	jsonMarshaler := &jsonpb.Marshaler{}
-
-	td := pdata.NewTraces()
-	rs := td.ResourceSpans().AppendEmpty()
-	rs.Resource().Attributes().Insert("test-key", pdata.NewAttributeValueString("test-val"))
-	ils := rs.InstrumentationLibrarySpans().AppendEmpty()
-
-	// Will add this span to the messages queue to export
-	span := ils.Spans().AppendEmpty()
-	span.SetName("foo")
-	span.SetStartTimestamp(pdata.Timestamp(10))
-	span.SetEndTimestamp(pdata.Timestamp(20))
-	span.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
-	span.SetSpanID(pdata.NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
-	span.Attributes().Insert("tag1", pdata.NewAttributeValueString("tag1-val"))
-
-	// Will log on this span that exceeds max message size.
-	span = ils.Spans().AppendEmpty()
-	span.SetName("bar")
-	span.SetStartTimestamp(pdata.Timestamp(100))
-	span.SetEndTimestamp(pdata.Timestamp(225))
-	span.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
-	span.SetSpanID(pdata.NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
-	span.Attributes().Insert("tag10", pdata.NewAttributeValueString("tag10-val"))
-	span.Attributes().Insert("big-tag", pdata.NewAttributeValueString(createLongString(maxMessageBytes, "a")))
-
-	batches, err := jaegertranslator.InternalTracesToJaegerProto(td)
-	require.NoError(t, err)
-
-	batches[0].Spans[0].Process = batches[0].Process
-	jaegerProtoBytes0, err := batches[0].Spans[0].Marshal()
-	messageKey := []byte(batches[0].Spans[0].TraceID.String())
-	require.NoError(t, err)
-	require.NotNil(t, jaegerProtoBytes0)
-
-	jsonByteBuffer0 := new(bytes.Buffer)
-	require.NoError(t, jsonMarshaler.Marshal(jsonByteBuffer0, batches[0].Spans[0]))
-
-	// expected cured spans should be similar to spans that came in as if they were already cured.
-	// batches[0].Spans[1] when cured will be the same as curedBatches[0].Spans[0]
-	curedTd := pdata.NewTraces()
-	curedRs := curedTd.ResourceSpans().AppendEmpty()
-	curedRs.Resource().Attributes().Insert("test-key", pdata.NewAttributeValueString("test-val"))
-	curedIls := curedRs.InstrumentationLibrarySpans().AppendEmpty()
-
-	curedSpan := curedIls.Spans().AppendEmpty()
-	curedSpan.SetName("bar")
-	curedSpan.SetStartTimestamp(pdata.Timestamp(100))
-	curedSpan.SetEndTimestamp(pdata.Timestamp(225))
-	curedSpan.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
-	curedSpan.SetSpanID(pdata.NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
-	curedSpan.Attributes().Insert("tag10", pdata.NewAttributeValueString("tag10-val"))
-	curedSpan.Attributes().Insert("big-tag", pdata.NewAttributeValueString(createLongString(maxAttributeValueSize, "a")))
-	curedSpan.Attributes().Insert("big-tag.truncated", pdata.NewAttributeValueBool(true))
-
-	curedBatches, err := jaegertranslator.InternalTracesToJaegerProto(curedTd)
-	require.NoError(t, err)
-
-	curedBatches[0].Spans[0].Process = curedBatches[0].Process
-	curedJaegerProtoBytes1, err := curedBatches[0].Spans[0].Marshal()
-	require.NoError(t, err)
-	require.NotNil(t, curedJaegerProtoBytes1)
-
-	curedJsonByteBuffer1 := new(bytes.Buffer)
-	require.NoError(t, jsonMarshaler.Marshal(curedJsonByteBuffer1, curedBatches[0].Spans[0]))
-
-	tests := []struct {
-		unmarshaler TracesMarshaler
-		encoding    string
-		messages    []*sarama.ProducerMessage
-	}{
-		{
-			unmarshaler: jaegerMarshalerDebug{
-				marshaler:             jaegerProtoSpanMarshaler{},
-				version:               sarama.V2_0_0_0,
-				maxMessageBytes:       maxMessageBytes,
-				maxAttributeValueSize: maxAttributeValueSize,
-				cureSpans:             true,
-			},
-			encoding: "jaeger_proto",
-			messages: []*sarama.ProducerMessage{
-				{Topic: "topic", Value: sarama.ByteEncoder(jaegerProtoBytes0), Key: sarama.ByteEncoder(messageKey)},
-				{Topic: "topic", Value: sarama.ByteEncoder(curedJaegerProtoBytes1), Key: sarama.ByteEncoder(messageKey)}},
-		},
-		{
-			unmarshaler: jaegerMarshalerDebug{
-				marshaler: jaegerJSONSpanMarshaler{
-					pbMarshaler: &jsonpb.Marshaler{},
-				},
-				version:               sarama.V2_0_0_0,
-				maxMessageBytes:       maxMessageBytes,
-				maxAttributeValueSize: maxAttributeValueSize,
-				cureSpans:             true,
-			},
-			encoding: "jaeger_json",
-			messages: []*sarama.ProducerMessage{
-				{Topic: "topic", Value: sarama.ByteEncoder(jsonByteBuffer0.Bytes()), Key: sarama.ByteEncoder(messageKey)},
-				{Topic: "topic", Value: sarama.ByteEncoder(curedJsonByteBuffer1.Bytes()), Key: sarama.ByteEncoder(messageKey)},
-			},
-		},
-		{
-			unmarshaler: jaegerMarshalerDebug{
-				marshaler:             jaegerProtoSpanMarshaler{},
-				version:               sarama.V2_0_0_0,
-				maxMessageBytes:       maxMessageBytes,
-				maxAttributeValueSize: maxAttributeValueSize,
-				dumpSpanAttributes:    true, // test setting this to true
-				cureSpans:             true,
-			},
-			encoding: "jaeger_proto",
-			messages: []*sarama.ProducerMessage{
-				{Topic: "topic", Value: sarama.ByteEncoder(jaegerProtoBytes0), Key: sarama.ByteEncoder(messageKey)},
-				{Topic: "topic", Value: sarama.ByteEncoder(curedJaegerProtoBytes1), Key: sarama.ByteEncoder(messageKey)}},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.encoding, func(t *testing.T) {
-			messages, err := test.unmarshaler.Marshal(td, "topic")
-			require.NoError(t, err)
-			assert.Equal(t, test.messages, messages)
-			assert.Equal(t, test.encoding, test.unmarshaler.Encoding())
-		})
-	}
 }
 
 func createLongString(n int, s string) string {

--- a/exporter/kafkaexporter/kafka_exporter.modified.go
+++ b/exporter/kafkaexporter/kafka_exporter.modified.go
@@ -173,7 +173,8 @@ func newMetricsExporter(config Config, set component.ExporterCreateSettings, mar
 }
 
 // newTracesExporter creates Kafka exporter. If SpanCuring.Enbaled is true and we are using "jaeger_proto" message encoding, we will switch out the
-// marshaler to jaegerMarshalerCurer which logs spans details for spans greater than config.Producer.MaxMessageBytes.
+// marshaler to jaegerMarshalerCurer which logs spans details for spans greater than config.Producer.MaxMessageBytes and "cures" them by
+// truncating large attribute string and byte array values.
 func newTracesExporter(config Config, set component.ExporterCreateSettings, marshalers map[string]TracesMarshaler) (*kafkaTracesProducer, error) {
 	marshaler := marshalers[config.Encoding]
 	if marshaler == nil {

--- a/exporter/kafkaexporter/kafka_exporter.modified.go
+++ b/exporter/kafkaexporter/kafka_exporter.modified.go
@@ -179,7 +179,7 @@ func newTracesExporter(config Config, set component.ExporterCreateSettings, mars
 	if marshaler == nil {
 		return nil, errUnrecognizedEncoding
 	}
-	if config.Debug && config.Encoding == "jaeger_proto" {
+	if config.SpanCuring.Enabled && config.Encoding == "jaeger_proto" {
 		v := sarama.V2_0_0_0
 		if config.ProtocolVersion != "" {
 			version, err := sarama.ParseKafkaVersion(config.ProtocolVersion)
@@ -187,13 +187,17 @@ func newTracesExporter(config Config, set component.ExporterCreateSettings, mars
 				v = version
 			}
 		}
+		maxAttributeValueSize := defaultMaxAttributeValueSize
+		if config.SpanCuring.MaxAttributeValueSize != 0 {
+			maxAttributeValueSize = config.SpanCuring.MaxAttributeValueSize
+		}
 		marshaler = jaegerMarshalerDebug{
 			marshaler:             jaegerProtoSpanMarshaler{},
 			version:               v,
 			maxMessageBytes:       config.Producer.MaxMessageBytes,
-			dumpSpanAttributes:    config.DumpSpanAttributes,
-			maxAttributeValueSize: defaultMaxAttributeValueSize,
-			cureSpans:             config.CureSpans,
+			dumpSpanAttributes:    config.SpanCuring.DumpSpanAttributes,
+			maxAttributeValueSize: maxAttributeValueSize,
+			dropSpans:             config.SpanCuring.DropSpans,
 		}
 	}
 	producer, err := newSaramaProducer(config)

--- a/exporter/kafkaexporter/kafka_exporter.modified.go
+++ b/exporter/kafkaexporter/kafka_exporter.modified.go
@@ -172,8 +172,8 @@ func newMetricsExporter(config Config, set component.ExporterCreateSettings, mar
 
 }
 
-// newTracesExporter creates Kafka exporter. If debug mode is turned on and we are using "jaeger_proto" message encoding, we will switch out the
-// marshaler to jaegerMarshalerDebug which logs spans details for spans greater than config.Producer.MaxMessageBytes.
+// newTracesExporter creates Kafka exporter. If SpanCuring.Enbaled is true and we are using "jaeger_proto" message encoding, we will switch out the
+// marshaler to jaegerMarshalerCurer which logs spans details for spans greater than config.Producer.MaxMessageBytes.
 func newTracesExporter(config Config, set component.ExporterCreateSettings, marshalers map[string]TracesMarshaler) (*kafkaTracesProducer, error) {
 	marshaler := marshalers[config.Encoding]
 	if marshaler == nil {
@@ -191,7 +191,7 @@ func newTracesExporter(config Config, set component.ExporterCreateSettings, mars
 		if config.SpanCuring.MaxAttributeValueSize != 0 {
 			maxAttributeValueSize = config.SpanCuring.MaxAttributeValueSize
 		}
-		marshaler = jaegerMarshalerDebug{
+		marshaler = jaegerMarshalerCurer{
 			marshaler:             jaegerProtoSpanMarshaler{},
 			version:               v,
 			maxMessageBytes:       config.Producer.MaxMessageBytes,

--- a/exporter/kafkaexporter/kafka_exporter.modified.go
+++ b/exporter/kafkaexporter/kafka_exporter.modified.go
@@ -188,10 +188,12 @@ func newTracesExporter(config Config, set component.ExporterCreateSettings, mars
 			}
 		}
 		marshaler = jaegerMarshalerDebug{
-			marshaler:          jaegerProtoSpanMarshaler{},
-			version:            v,
-			maxMessageBytes:    config.Producer.MaxMessageBytes,
-			dumpSpanAttributes: config.DumpSpanAttributes,
+			marshaler:             jaegerProtoSpanMarshaler{},
+			version:               v,
+			maxMessageBytes:       config.Producer.MaxMessageBytes,
+			dumpSpanAttributes:    config.DumpSpanAttributes,
+			maxAttributeValueSize: defaultMaxAttributeValueSize,
+			cureSpans:             config.CureSpans,
 		}
 	}
 	producer, err := newSaramaProducer(config)

--- a/exporter/kafkaexporter/testdata/config_modified.yaml
+++ b/exporter/kafkaexporter/testdata/config_modified.yaml
@@ -30,6 +30,7 @@ exporters:
       level: 8
     debug: true
     dump_span_attributes: true
+    cure_spans: true
 
 processors:
   nop:

--- a/exporter/kafkaexporter/testdata/config_modified.yaml
+++ b/exporter/kafkaexporter/testdata/config_modified.yaml
@@ -30,7 +30,11 @@ exporters:
       level: 8
     debug: true
     dump_span_attributes: true
-    cure_spans: true
+    span_curing:
+      enabled: true
+      drop_spans: true
+      max_attribute_value_size: 131072
+      dump_span_attributes: true
 
 processors:
   nop:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -166,6 +166,11 @@ configMap:
         compression:
           codec: gzip #[none,gzip,snappy,lz4]
           level: 5 #Required only for gzip 1-9
+        span_curing:
+          enabled: true
+          # Drop spans that cannot be cured and will eventually end up being dropped anyway
+          # after multiple retries.
+          drop_spans: true
       prometheus:
         endpoint: "0.0.0.0:8889"
         #For converting resource attributes to metric labels


### PR DESCRIPTION
## Description
For the kafka exporter, large spans - by default those over 1MB - cause an error in exporting and end up in the retry queue where they hold up the memory, eventually causing the process to run out of allocated memory and crash. We'd like to be able to "cure" the large spans by truncating the tag values to 128KiB(which is configurable)

### Testing
- comprehensive unit tests

### Checklist:
- [ ✅ ] My changes generate no new warnings
- [✅  ] I have added tests that prove my fix is effective or that my feature works

