### PR TITLE
fix: remove no longer supported --metrics-addr

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
           command:
             - "/usr/local/bin/hypertrace/collector"
             - "--config=/conf/hypertrace-collector-config.yaml"
-            - "--metrics-addr={{ .Values.metricsAddress }}"
+            - "--set=service.telemetry.metrics.address={{ .Values.metricsAddress }}"
           ports:
           {{ range $port := .Values.containerPorts }}
             - name: {{ $port.name }}


### PR DESCRIPTION
## Description
From otel collector v0.43.0 notes
```
- Remove deprecate flags --metrics-level and --metrics-addr (#4695)
  - Usages of `--metrics-level={VALUE}` can be replaced by `--set=service.telemetry.metrics.level={VALUE}`;
  - Usages of `--metrics-addr={VALUE}` can be replaced by `--set=service.telemetry.metrics.address={VALUE}`;
  ```



### Testing
Tested build locally

### Checklist:
- [✅  ] My changes generate no new warnings
