### PR TITLE
chore: remove deprecated debug and dump_span_attributes kafkaexporter config

### DIFF
--- a/exporter/kafkaexporter/config.modified.go
+++ b/exporter/kafkaexporter/config.modified.go
@@ -54,15 +54,6 @@ type Config struct {
 	// Compression defines the compression method and compression level, if applicable.
 	Compression Compression `mapstructure:"compression"`
 
-	// Debug. Log info for spans that exceed Producer.MaxMessageBytes early.
-	// [Deprecated]
-	Debug bool `mapstructure:"debug"`
-
-	// Dump all span attributes. Works when Debug above is set to true. Will dump
-	// all the span attribute values for spans that exceed Producer.MaxMessageBytes
-	// [Deprecated]
-	DumpSpanAttributes bool `mapstructure:"dump_span_attributes"`
-
 	// SpanCuring defines config to "cure" large spans that exceed Producer.MaxMessageBytes so that
 	// they are able to be exported
 	SpanCuring SpanCuring `mapstructure:"span_curing"`

--- a/exporter/kafkaexporter/config_modified_test.go
+++ b/exporter/kafkaexporter/config_modified_test.go
@@ -79,8 +79,6 @@ func TestLoadConfig(t *testing.T) {
 			Codec: "gzip",
 			Level: 8,
 		},
-		Debug:              true,
-		DumpSpanAttributes: true,
 		SpanCuring: SpanCuring{
 			Enabled:                    true,
 			DropSpans:                  true,

--- a/exporter/kafkaexporter/testdata/config_modified.yaml
+++ b/exporter/kafkaexporter/testdata/config_modified.yaml
@@ -28,8 +28,6 @@ exporters:
     compression:
       codec: gzip
       level: 8
-    debug: true
-    dump_span_attributes: true
     span_curing:
       enabled: true
       drop_spans: true


### PR DESCRIPTION
## Description
This was used to debug a memory leak that would lead to the pod crashing. We fixed that with span curing and so we no longer need this. I've ensured that none of our deployments are still using the config.

### Testing
Unit tests

### Checklist:
- [✅  ] My changes generate no new warnings
- [ ✅ ] Any dependent changes have been merged and published in downstream modules

