### PR TITLE
feat: add processor to copy over metrics resource attributes to metric datapoint attributes

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/collector/service"
 	"go.uber.org/multierr"
 
+	"github.com/hypertrace/collector/processors/metricresourceattrstoattrs"
 	"github.com/hypertrace/collector/processors/tenantidprocessor"
 )
 
@@ -72,6 +73,9 @@ func components() (component.Factories, error) {
 
 	tidpf := tenantidprocessor.NewFactory()
 	factories.Processors[tidpf.Type()] = tidpf
+
+	mrata := metricresourceattrstoattrs.NewFactory()
+	factories.Processors[mrata.Type()] = mrata
 
 	fef := fileexporter.NewFactory()
 	factories.Exporters[fef.Type()] = fef

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -155,6 +155,7 @@ configMap:
             endpoint: "0.0.0.0:14268"
     processors:
       batch: {}
+      hypertrace_metrics_resource_attrs_to_attrs:
 
     exporters:
       kafka:
@@ -175,9 +176,13 @@ configMap:
           compression: gzip
       prometheus:
         endpoint: "0.0.0.0:8889"
-        #For converting resource attributes to metric labels
+        # For converting resource attributes to metric labels we will use the hypertrace_metrics_resource_attrs_to_attrs
+        # processor so that we avoid adding job and instance labels as the prometheus exporter will add them.
+        # See https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/12cc610f93429fbd9dec71c5f486d266844f11c2/exporter/prometheusexporter/collector.go#L96
+        # Once this is fixed we can re-enable this.
+        # Filed issue https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10374
         resource_to_telemetry_conversion:
-          enabled: true
+          enabled: false
 
     service:
       telemetry:
@@ -191,7 +196,7 @@ configMap:
           exporters: [kafka]
         metrics:
           receivers: [otlp]
-          processors: [batch]
+          processors: [batch, hypertrace_metrics_resource_attrs_to_attrs]
           exporters: [prometheus]
 
 hpa:

--- a/processors/metricresourceattrstoattrs/README.md
+++ b/processors/metricresourceattrstoattrs/README.md
@@ -1,0 +1,14 @@
+# metricresourceattrstoattrs processor
+
+The purpose of this processor is to copy over the resource attributes to the metric data point attributes with the exception of `job` and `instance` if present when `service.name` and `service.instance.id` are present. This is because the prometheus exporter, while scraping, adds them again and this might cause a `duplicate label names` error to be thrown back.
+
+This is caused by the change added in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9115. More specifically https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/12cc610f93429fbd9dec71c5f486d266844f11c2/exporter/prometheusexporter/collector.go#L96
+
+
+It similar to setting prometheus exporter's resource_to_telemetry_conversion enabled config to true with the above caveat.
+```
+prometheus:
+  endpoint: "0.0.0.0:8889"
+  resource_to_telemetry_conversion:
+    enabled: true
+```

--- a/processors/metricresourceattrstoattrs/config.go
+++ b/processors/metricresourceattrstoattrs/config.go
@@ -1,0 +1,9 @@
+package metricresourceattrstoattrs
+
+import (
+	"go.opentelemetry.io/collector/config"
+)
+
+type Config struct {
+	config.ProcessorSettings `mapstructure:"-"`
+}

--- a/processors/metricresourceattrstoattrs/factory.go
+++ b/processors/metricresourceattrstoattrs/factory.go
@@ -1,0 +1,46 @@
+package metricresourceattrstoattrs
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/processor/processorhelper"
+)
+
+const (
+	typeStr = "hypertrace_metrics_resource_attrs_to_attrs"
+)
+
+// NewFactory creates a factory for the metricresourceattrstoattrs processor.
+func NewFactory() component.ProcessorFactory {
+	return component.NewProcessorFactory(
+		typeStr,
+		createDefaultConfig,
+		component.WithMetricsProcessor(createMetricsProcessor),
+	)
+}
+
+func createDefaultConfig() config.Processor {
+	return &Config{
+		ProcessorSettings: config.NewProcessorSettings(
+			config.NewComponentID(typeStr),
+		),
+	}
+}
+
+func createMetricsProcessor(
+	_ context.Context,
+	params component.ProcessorCreateSettings,
+	cfg config.Processor,
+	nextConsumer consumer.Metrics,
+) (component.MetricsProcessor, error) {
+	processor := &processor{
+		logger: params.Logger,
+	}
+	return processorhelper.NewMetricsProcessor(
+		cfg,
+		nextConsumer,
+		processor.ProcessMetrics)
+}

--- a/processors/metricresourceattrstoattrs/factory_test.go
+++ b/processors/metricresourceattrstoattrs/factory_test.go
@@ -1,0 +1,14 @@
+package metricresourceattrstoattrs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewFactory(t *testing.T) {
+	f := NewFactory()
+	assert.NotNil(t, f)
+
+	assert.NotNil(t, f.CreateDefaultConfig())
+}

--- a/processors/metricresourceattrstoattrs/metricresourcesattrstolabels.go
+++ b/processors/metricresourceattrstoattrs/metricresourcesattrstolabels.go
@@ -1,0 +1,77 @@
+package metricresourceattrstoattrs
+
+import (
+	"context"
+
+	"github.com/prometheus/common/model"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+type processor struct {
+	logger *zap.Logger
+}
+
+// ProcessMetrics implements processorhelper.ProcessMetricsFunc
+func (p *processor) ProcessMetrics(ctx context.Context, metrics pmetric.Metrics) (pmetric.Metrics, error) {
+	rms := metrics.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		rm := rms.At(i)
+		resourceAttrs := rm.Resource().Attributes()
+		// Check if service.name and service.instance.id are set as resource attributes since in
+		// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/12cc610f93429fbd9dec71c5f486d266844f11c2/exporter/prometheusexporter/collector.go#L96
+		// they are used to add job and instance metric labels.
+		_, hasResourceServiceNameAttr := resourceAttrs.Get(conventions.AttributeServiceName)
+		_, hasResourceServiceInstanceIDAttr := resourceAttrs.Get(conventions.AttributeServiceInstanceID)
+		sms := rm.ScopeMetrics()
+		for j := 0; j < sms.Len(); j++ {
+			sm := sms.At(j)
+			metrics := sm.Metrics()
+			for k := 0; k < metrics.Len(); k++ {
+				metric := metrics.At(k)
+				// Add all resource attributes to labels except for:
+				// - model.JobLabel if hasResourceServiceNameAttr is true
+				// - model.InstanceLabel if hasResourceServiceInstanceIDAttr is true
+				// These will be added by the prometheus exporter.
+				resourceAttrs.Range(func(key string, v pcommon.Value) bool {
+					if (key == model.JobLabel && hasResourceServiceNameAttr) ||
+						(key == model.InstanceLabel && hasResourceServiceInstanceIDAttr) {
+						return true
+					}
+					metricDataType := metric.DataType()
+					switch metricDataType {
+					case pmetric.MetricDataTypeGauge:
+						metricData := metric.Gauge().DataPoints()
+						for l := 0; l < metricData.Len(); l++ {
+							metricData.At(l).Attributes().Insert(key, v)
+						}
+					case pmetric.MetricDataTypeSum:
+						metricData := metric.Sum().DataPoints()
+						for l := 0; l < metricData.Len(); l++ {
+							metricData.At(l).Attributes().Insert(key, v)
+						}
+					case pmetric.MetricDataTypeHistogram:
+						metricData := metric.Histogram().DataPoints()
+						for l := 0; l < metricData.Len(); l++ {
+							metricData.At(l).Attributes().Insert(key, v)
+						}
+					case pmetric.MetricDataTypeExponentialHistogram:
+						metricData := metric.ExponentialHistogram().DataPoints()
+						for l := 0; l < metricData.Len(); l++ {
+							metricData.At(l).Attributes().Insert(key, v)
+						}
+					case pmetric.MetricDataTypeSummary:
+						metricData := metric.Summary().DataPoints()
+						for l := 0; l < metricData.Len(); l++ {
+							metricData.At(l).Attributes().Insert(key, v)
+						}
+					}
+					return true
+				})
+			}
+		}
+	}
+	return metrics, nil
+}

--- a/processors/metricresourceattrstoattrs/metricresourcesattrstolabels_test.go
+++ b/processors/metricresourceattrstoattrs/metricresourcesattrstolabels_test.go
@@ -1,0 +1,256 @@
+package metricresourceattrstoattrs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+func TestEmptyMetrics(t *testing.T) {
+	p := &processor{
+		logger: zap.NewNop(),
+	}
+	metrics := pmetric.NewMetrics()
+	gotMetrics, err := p.ProcessMetrics(context.Background(), metrics)
+	require.NoError(t, err)
+	assert.Equal(t, metrics, gotMetrics)
+}
+
+func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
+	logger := zap.NewNop()
+	testCases := map[string]struct {
+		inputResourceAttributes  map[string]string
+		inputMetricAttributes    map[string]string
+		expectedMetricAttributes map[string]string
+		dt                       pmetric.MetricDataType
+	}{
+		"all concerned resource attrs present for sum metric: job and instance labels not added": {
+			inputResourceAttributes: map[string]string{
+				conventions.AttributeServiceName:       "test-service",
+				conventions.AttributeServiceInstanceID: "test-instance-id",
+				model.JobLabel:                         "test-job-name",
+				model.InstanceLabel:                    "test-instance",
+				"port":                                 "8888",
+				"scheme":                               "http",
+			},
+			inputMetricAttributes: map[string]string{
+				"foo10": "baz10",
+				"foo11": "baz11",
+			},
+			expectedMetricAttributes: map[string]string{
+				"foo10":                                "baz10",
+				"foo11":                                "baz11",
+				conventions.AttributeServiceName:       "test-service",
+				conventions.AttributeServiceInstanceID: "test-instance-id",
+				"port":                                 "8888",
+				"scheme":                               "http",
+			},
+			dt: pmetric.MetricDataTypeSum,
+		},
+		"service name and instance id resource attrs not present for sum metric: job and instance labels are added": {
+			inputResourceAttributes: map[string]string{
+				model.JobLabel:      "test-job-name",
+				model.InstanceLabel: "test-instance",
+				"port":              "8888",
+				"scheme":            "http",
+			},
+			inputMetricAttributes: map[string]string{
+				"foo10": "baz10",
+				"foo11": "baz11",
+			},
+			expectedMetricAttributes: map[string]string{
+				"foo10":             "baz10",
+				"foo11":             "baz11",
+				model.JobLabel:      "test-job-name",
+				model.InstanceLabel: "test-instance",
+				"port":              "8888",
+				"scheme":            "http",
+			},
+			dt: pmetric.MetricDataTypeSum,
+		},
+		"all concerned resource attrs present for gauge metric: job and instance labels not added": {
+			inputResourceAttributes: map[string]string{
+				conventions.AttributeServiceName:       "test-service",
+				conventions.AttributeServiceInstanceID: "test-instance-id",
+				model.JobLabel:                         "test-job-name",
+				model.InstanceLabel:                    "test-instance",
+				"port":                                 "8888",
+			},
+			inputMetricAttributes: map[string]string{
+				"foo10": "baz10",
+			},
+			expectedMetricAttributes: map[string]string{
+				"foo10":                                "baz10",
+				conventions.AttributeServiceName:       "test-service",
+				conventions.AttributeServiceInstanceID: "test-instance-id",
+				"port":                                 "8888",
+			},
+			dt: pmetric.MetricDataTypeGauge,
+		},
+		"all concerned resource attrs present for histogram metric: job and instance labels not added": {
+			inputResourceAttributes: map[string]string{
+				conventions.AttributeServiceName:       "test-service",
+				conventions.AttributeServiceInstanceID: "test-instance-id",
+				model.JobLabel:                         "test-job-name",
+				model.InstanceLabel:                    "test-instance",
+				"port":                                 "8888",
+			},
+			inputMetricAttributes: map[string]string{
+				"foo10": "baz10",
+			},
+			expectedMetricAttributes: map[string]string{
+				"foo10":                                "baz10",
+				conventions.AttributeServiceName:       "test-service",
+				conventions.AttributeServiceInstanceID: "test-instance-id",
+				"port":                                 "8888",
+			},
+			dt: pmetric.MetricDataTypeHistogram,
+		},
+		"all concerned resource attrs present for exponential histogram metric: job and instance labels not added": {
+			inputResourceAttributes: map[string]string{
+				conventions.AttributeServiceName:       "test-service",
+				conventions.AttributeServiceInstanceID: "test-instance-id",
+				model.JobLabel:                         "test-job-name",
+				model.InstanceLabel:                    "test-instance",
+				"port":                                 "8888",
+			},
+			inputMetricAttributes: map[string]string{
+				"foo10": "baz10",
+			},
+			expectedMetricAttributes: map[string]string{
+				"foo10":                                "baz10",
+				conventions.AttributeServiceName:       "test-service",
+				conventions.AttributeServiceInstanceID: "test-instance-id",
+				"port":                                 "8888",
+			},
+			dt: pmetric.MetricDataTypeExponentialHistogram,
+		},
+		"all concerned resource attrs present for summary metric: job and instance labels not added": {
+			inputResourceAttributes: map[string]string{
+				conventions.AttributeServiceName:       "test-service",
+				conventions.AttributeServiceInstanceID: "test-instance-id",
+				model.JobLabel:                         "test-job-name",
+				model.InstanceLabel:                    "test-instance",
+				"port":                                 "8888",
+			},
+			inputMetricAttributes: map[string]string{
+				"foo10": "baz10",
+			},
+			expectedMetricAttributes: map[string]string{
+				"foo10":                                "baz10",
+				conventions.AttributeServiceName:       "test-service",
+				conventions.AttributeServiceInstanceID: "test-instance-id",
+				"port":                                 "8888",
+			},
+			dt: pmetric.MetricDataTypeSummary,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			metrics := generateMetricData(
+				testCase.inputResourceAttributes,
+				testCase.inputMetricAttributes,
+				testCase.dt,
+			)
+			expectedProcessedMetrics := generateMetricData(
+				testCase.inputResourceAttributes,
+				testCase.expectedMetricAttributes,
+				testCase.dt,
+			)
+
+			p := processor{logger: logger}
+
+			processedMetrics, err := p.ProcessMetrics(context.Background(), metrics)
+			assert.Nil(t, err)
+			// resource attrs should not change
+			verifyAttributesEquality(
+				t,
+				expectedProcessedMetrics.ResourceMetrics().At(0).Resource().Attributes(),
+				processedMetrics.ResourceMetrics().At(0).Resource().Attributes(),
+			)
+			// metric data point attributes can change
+			expectedProcessedMetric := expectedProcessedMetrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+			processedMetric := processedMetrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+			verifyAttributesEquality(
+				t,
+				getMetricDataPointAttributes(expectedProcessedMetric, testCase.dt),
+				getMetricDataPointAttributes(processedMetric, testCase.dt),
+			)
+		})
+	}
+}
+
+func generateMetricData(resourceAttrs map[string]string, attrs map[string]string, dt pmetric.MetricDataType) pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	md.ResourceMetrics().AppendEmpty()
+	for k, v := range resourceAttrs {
+		md.ResourceMetrics().At(0).Resource().Attributes().Insert(k, pcommon.NewValueString(v))
+	}
+	md.ResourceMetrics().At(0).ScopeMetrics().AppendEmpty()
+	md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().AppendEmpty()
+	metric := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+	metric.SetDataType(dt)
+	switch dt {
+	case pmetric.MetricDataTypeSum:
+		metric.Sum().DataPoints().AppendEmpty()
+		for k, v := range attrs {
+			metric.Sum().DataPoints().At(0).Attributes().Insert(k, pcommon.NewValueString(v))
+		}
+	case pmetric.MetricDataTypeGauge:
+		metric.Gauge().DataPoints().AppendEmpty()
+		for k, v := range attrs {
+			metric.Gauge().DataPoints().At(0).Attributes().Insert(k, pcommon.NewValueString(v))
+		}
+	case pmetric.MetricDataTypeHistogram:
+		metric.Histogram().DataPoints().AppendEmpty()
+		for k, v := range attrs {
+			metric.Histogram().DataPoints().At(0).Attributes().Insert(k, pcommon.NewValueString(v))
+		}
+	case pmetric.MetricDataTypeExponentialHistogram:
+		metric.ExponentialHistogram().DataPoints().AppendEmpty()
+		for k, v := range attrs {
+			metric.ExponentialHistogram().DataPoints().At(0).Attributes().Insert(k, pcommon.NewValueString(v))
+		}
+	case pmetric.MetricDataTypeSummary:
+		metric.Summary().DataPoints().AppendEmpty()
+		for k, v := range attrs {
+			metric.Summary().DataPoints().At(0).Attributes().Insert(k, pcommon.NewValueString(v))
+		}
+	}
+	return md
+}
+
+func getMetricDataPointAttributes(metric pmetric.Metric, dt pmetric.MetricDataType) pcommon.Map {
+	switch dt {
+	case pmetric.MetricDataTypeSum:
+		return metric.Sum().DataPoints().At(0).Attributes()
+	case pmetric.MetricDataTypeGauge:
+		return metric.Gauge().DataPoints().At(0).Attributes()
+	case pmetric.MetricDataTypeHistogram:
+		return metric.Histogram().DataPoints().At(0).Attributes()
+	case pmetric.MetricDataTypeExponentialHistogram:
+		return metric.ExponentialHistogram().DataPoints().At(0).Attributes()
+	case pmetric.MetricDataTypeSummary:
+		return metric.Summary().DataPoints().At(0).Attributes()
+	}
+
+	return pcommon.NewMap()
+}
+
+func verifyAttributesEquality(t *testing.T, m1 pcommon.Map, m2 pcommon.Map) {
+	assert.Equal(t, m1.Len(), m2.Len())
+	m1.Range(func(k string, v pcommon.Value) bool {
+		v2, ok := m2.Get(k)
+		assert.Truef(t, ok, "m2 does not have key %s found in m1", k)
+		assert.Equalf(t, v, v2, "m2 has a different value for key %s. val: %v", k, v2)
+		return true
+	})
+}


### PR DESCRIPTION
## Description
In order to get around https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10374 we use this processor to copy the resource attributes to attributes instead of setting resource_to_telemetry_conversion enabled prometheus exporter config. This processor avoids copying the `job` if `service.name` exists and `instance` if `service.instance.id` exists.

### Testing
Unit tests and tested locally e2e.

### Checklist:
- [✅  ] My changes generate no new warnings
- [✅  ] I have added tests that prove my fix is effective or that my feature works
- [✅  ] Any dependent changes have been merged and published in downstream modules

### Documentation
Added a README for the processor.
