### PR TITLE
fix: null processor helm value being removed by newer helm versions when merging

### DIFF
--- a/default-config.yml
+++ b/default-config.yml
@@ -23,7 +23,7 @@ receivers:
   zipkin:
 
 processors:
-  batch:
+  batch: {}
 
 exporters:
   kafka:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -155,7 +155,7 @@ configMap:
             endpoint: "0.0.0.0:14268"
     processors:
       batch: {}
-      hypertrace_metrics_resource_attrs_to_attrs:
+      hypertrace_metrics_resource_attrs_to_attrs: {}
 
     exporters:
       kafka:

--- a/processors/metricresourceattrstoattrs/README.md
+++ b/processors/metricresourceattrstoattrs/README.md
@@ -12,3 +12,5 @@ prometheus:
   resource_to_telemetry_conversion:
     enabled: true
 ```
+
+Filed an issue with otel collector contrib: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10374


### PR DESCRIPTION
## Description
In newer helm versions if the helm value being merged from a custom values.yaml has a null value, it's removed. So for the `hypertrace_metrics_resource_attrs_to_attrs` we will modify it to `hypertrace_metrics_resource_attrs_to_attrs: {}`

### Testing
Verified that the collector comes up locally

### Checklist:
- [ ✅ ] My changes generate no new warnings
- [ ✅ ] Any dependent changes have been merged and published in downstream modules

