### PR TITLE
fix: remove job and instance metric attributes if prometheus exporter will add them later on

### DIFF
--- a/processors/metricresourceattrstoattrs/metricresourcesattrstolabels.go
+++ b/processors/metricresourceattrstoattrs/metricresourcesattrstolabels.go
@@ -40,8 +40,7 @@ func (p *processor) ProcessMetrics(ctx context.Context, metrics pmetric.Metrics)
 						(key == model.InstanceLabel && hasResourceServiceInstanceIDAttr) {
 						return true
 					}
-					addResourceAttributeToMetricAttributes(metric, hasResourceServiceNameAttr, hasResourceServiceInstanceIDAttr,
-						key, v)
+					addResourceAttributeToMetricAttributes(metric, key, v)
 					return true
 				})
 				removeJobAndInstanceLabels(metric, hasResourceServiceNameAttr, hasResourceServiceInstanceIDAttr)
@@ -52,8 +51,7 @@ func (p *processor) ProcessMetrics(ctx context.Context, metrics pmetric.Metrics)
 }
 
 // addResourceAttributeToMetricAttributes is the workhorse to add resource attributes to metric attributes
-func addResourceAttributeToMetricAttributes(metric pmetric.Metric, hasResourceServiceNameAttr bool, hasResourceServiceInstanceIDAttr bool,
-	key string, v pcommon.Value) {
+func addResourceAttributeToMetricAttributes(metric pmetric.Metric, key string, v pcommon.Value) {
 	metricDataType := metric.DataType()
 	switch metricDataType {
 	case pmetric.MetricDataTypeGauge:

--- a/processors/metricresourceattrstoattrs/metricresourcesattrstolabels.go
+++ b/processors/metricresourceattrstoattrs/metricresourcesattrstolabels.go
@@ -40,103 +40,59 @@ func (p *processor) ProcessMetrics(ctx context.Context, metrics pmetric.Metrics)
 						(key == model.InstanceLabel && hasResourceServiceInstanceIDAttr) {
 						return true
 					}
-					addResourceAttributeToMetricAttributes(metric, key, v)
+					applyToMetricAttributes(metric, func(am pcommon.Map) {
+						am.Insert(key, v)
+					})
 					return true
 				})
-				removeJobAndInstanceLabels(metric, hasResourceServiceNameAttr, hasResourceServiceInstanceIDAttr)
+				// Remove job and instance labels from the metric attributes if hasResourceServiceNameAttr OR hasResourceServiceInstanceIDAttr is true.
+				// This is because they will be added by the prometheus exporter based on serviceName and serviceInstanceId
+				// and if already present they will be duplicated and will cause an error while processing metrics.
+				if hasResourceServiceNameAttr || hasResourceServiceInstanceIDAttr {
+					applyToMetricAttributes(metric, func(am pcommon.Map) {
+						if hasResourceServiceNameAttr {
+							am.Remove(model.JobLabel)
+						}
+						if hasResourceServiceInstanceIDAttr {
+							am.Remove(model.InstanceLabel)
+						}
+					})
+				}
 			}
 		}
 	}
 	return metrics, nil
 }
 
-// addResourceAttributeToMetricAttributes is the workhorse to add resource attributes to metric attributes
-func addResourceAttributeToMetricAttributes(metric pmetric.Metric, key string, v pcommon.Value) {
+// applyToMetricAttributes casts out the correct struct type for the metric so that it can access the attributes map and apply a function
+// to it.
+func applyToMetricAttributes(metric pmetric.Metric, fn func(pcommon.Map)) {
 	metricDataType := metric.DataType()
 	switch metricDataType {
 	case pmetric.MetricDataTypeGauge:
 		metricData := metric.Gauge().DataPoints()
 		for l := 0; l < metricData.Len(); l++ {
-			metricData.At(l).Attributes().Insert(key, v)
+			fn(metricData.At(l).Attributes())
 		}
 	case pmetric.MetricDataTypeSum:
 		metricData := metric.Sum().DataPoints()
 		for l := 0; l < metricData.Len(); l++ {
-			metricData.At(l).Attributes().Insert(key, v)
+			fn(metricData.At(l).Attributes())
 		}
 	case pmetric.MetricDataTypeHistogram:
 		metricData := metric.Histogram().DataPoints()
 		for l := 0; l < metricData.Len(); l++ {
-			metricData.At(l).Attributes().Insert(key, v)
+			fn(metricData.At(l).Attributes())
 		}
 	case pmetric.MetricDataTypeExponentialHistogram:
 		metricData := metric.ExponentialHistogram().DataPoints()
 		for l := 0; l < metricData.Len(); l++ {
-			metricData.At(l).Attributes().Insert(key, v)
+			fn(metricData.At(l).Attributes())
 		}
 	case pmetric.MetricDataTypeSummary:
 		metricData := metric.Summary().DataPoints()
 		for l := 0; l < metricData.Len(); l++ {
-			metricData.At(l).Attributes().Insert(key, v)
-		}
-	}
-}
-
-// removeJobAndInstanceLabels removes model.JobLabel if hasResourceServiceNameAttr and model.InstanceLabel if hasResourceServiceInstanceIDAttr,
-// from the metric attributes. This is because they will be added by the prometheus exporter based on serviceName and serviceInstanceId
-// and if already present they will be duplicate and will cause an error while processing metrics.
-func removeJobAndInstanceLabels(metric pmetric.Metric, hasResourceServiceNameAttr bool, hasResourceServiceInstanceIDAttr bool) {
-	metricDataType := metric.DataType()
-	switch metricDataType {
-	case pmetric.MetricDataTypeGauge:
-		metricData := metric.Gauge().DataPoints()
-		for l := 0; l < metricData.Len(); l++ {
-			if hasResourceServiceNameAttr {
-				metricData.At(l).Attributes().Remove(model.JobLabel)
-			}
-			if hasResourceServiceInstanceIDAttr {
-				metricData.At(l).Attributes().Remove(model.InstanceLabel)
-			}
-		}
-	case pmetric.MetricDataTypeSum:
-		metricData := metric.Sum().DataPoints()
-		for l := 0; l < metricData.Len(); l++ {
-			if hasResourceServiceNameAttr {
-				metricData.At(l).Attributes().Remove(model.JobLabel)
-			}
-			if hasResourceServiceInstanceIDAttr {
-				metricData.At(l).Attributes().Remove(model.InstanceLabel)
-			}
-		}
-	case pmetric.MetricDataTypeHistogram:
-		metricData := metric.Histogram().DataPoints()
-		for l := 0; l < metricData.Len(); l++ {
-			if hasResourceServiceNameAttr {
-				metricData.At(l).Attributes().Remove(model.JobLabel)
-			}
-			if hasResourceServiceInstanceIDAttr {
-				metricData.At(l).Attributes().Remove(model.InstanceLabel)
-			}
-		}
-	case pmetric.MetricDataTypeExponentialHistogram:
-		metricData := metric.ExponentialHistogram().DataPoints()
-		for l := 0; l < metricData.Len(); l++ {
-			if hasResourceServiceNameAttr {
-				metricData.At(l).Attributes().Remove(model.JobLabel)
-			}
-			if hasResourceServiceInstanceIDAttr {
-				metricData.At(l).Attributes().Remove(model.InstanceLabel)
-			}
-		}
-	case pmetric.MetricDataTypeSummary:
-		metricData := metric.Summary().DataPoints()
-		for l := 0; l < metricData.Len(); l++ {
-			if hasResourceServiceNameAttr {
-				metricData.At(l).Attributes().Remove(model.JobLabel)
-			}
-			if hasResourceServiceInstanceIDAttr {
-				metricData.At(l).Attributes().Remove(model.InstanceLabel)
-			}
+			fn(metricData.At(l).Attributes())
 		}
 	}
 }

--- a/processors/metricresourceattrstoattrs/metricresourcesattrstolabels.go
+++ b/processors/metricresourceattrstoattrs/metricresourcesattrstolabels.go
@@ -40,38 +40,105 @@ func (p *processor) ProcessMetrics(ctx context.Context, metrics pmetric.Metrics)
 						(key == model.InstanceLabel && hasResourceServiceInstanceIDAttr) {
 						return true
 					}
-					metricDataType := metric.DataType()
-					switch metricDataType {
-					case pmetric.MetricDataTypeGauge:
-						metricData := metric.Gauge().DataPoints()
-						for l := 0; l < metricData.Len(); l++ {
-							metricData.At(l).Attributes().Insert(key, v)
-						}
-					case pmetric.MetricDataTypeSum:
-						metricData := metric.Sum().DataPoints()
-						for l := 0; l < metricData.Len(); l++ {
-							metricData.At(l).Attributes().Insert(key, v)
-						}
-					case pmetric.MetricDataTypeHistogram:
-						metricData := metric.Histogram().DataPoints()
-						for l := 0; l < metricData.Len(); l++ {
-							metricData.At(l).Attributes().Insert(key, v)
-						}
-					case pmetric.MetricDataTypeExponentialHistogram:
-						metricData := metric.ExponentialHistogram().DataPoints()
-						for l := 0; l < metricData.Len(); l++ {
-							metricData.At(l).Attributes().Insert(key, v)
-						}
-					case pmetric.MetricDataTypeSummary:
-						metricData := metric.Summary().DataPoints()
-						for l := 0; l < metricData.Len(); l++ {
-							metricData.At(l).Attributes().Insert(key, v)
-						}
-					}
+					addResourceAttributeToMetricAttributes(metric, hasResourceServiceNameAttr, hasResourceServiceInstanceIDAttr,
+						key, v)
 					return true
 				})
+				removeJobAndInstanceLabels(metric, hasResourceServiceNameAttr, hasResourceServiceInstanceIDAttr)
 			}
 		}
 	}
 	return metrics, nil
+}
+
+// addResourceAttributeToMetricAttributes is the workhorse to add resource attributes to metric attributes
+func addResourceAttributeToMetricAttributes(metric pmetric.Metric, hasResourceServiceNameAttr bool, hasResourceServiceInstanceIDAttr bool,
+	key string, v pcommon.Value) {
+	metricDataType := metric.DataType()
+	switch metricDataType {
+	case pmetric.MetricDataTypeGauge:
+		metricData := metric.Gauge().DataPoints()
+		for l := 0; l < metricData.Len(); l++ {
+			metricData.At(l).Attributes().Insert(key, v)
+		}
+	case pmetric.MetricDataTypeSum:
+		metricData := metric.Sum().DataPoints()
+		for l := 0; l < metricData.Len(); l++ {
+			metricData.At(l).Attributes().Insert(key, v)
+		}
+	case pmetric.MetricDataTypeHistogram:
+		metricData := metric.Histogram().DataPoints()
+		for l := 0; l < metricData.Len(); l++ {
+			metricData.At(l).Attributes().Insert(key, v)
+		}
+	case pmetric.MetricDataTypeExponentialHistogram:
+		metricData := metric.ExponentialHistogram().DataPoints()
+		for l := 0; l < metricData.Len(); l++ {
+			metricData.At(l).Attributes().Insert(key, v)
+		}
+	case pmetric.MetricDataTypeSummary:
+		metricData := metric.Summary().DataPoints()
+		for l := 0; l < metricData.Len(); l++ {
+			metricData.At(l).Attributes().Insert(key, v)
+		}
+	}
+}
+
+// removeJobAndInstanceLabels removes model.JobLabel if hasResourceServiceNameAttr and model.InstanceLabel if hasResourceServiceInstanceIDAttr,
+// from the metric attributes. This is because they will be added by the prometheus exporter based on serviceName and serviceInstanceId
+// and if already present they will be duplicate and will cause an error while processing metrics.
+func removeJobAndInstanceLabels(metric pmetric.Metric, hasResourceServiceNameAttr bool, hasResourceServiceInstanceIDAttr bool) {
+	metricDataType := metric.DataType()
+	switch metricDataType {
+	case pmetric.MetricDataTypeGauge:
+		metricData := metric.Gauge().DataPoints()
+		for l := 0; l < metricData.Len(); l++ {
+			if hasResourceServiceNameAttr {
+				metricData.At(l).Attributes().Remove(model.JobLabel)
+			}
+			if hasResourceServiceInstanceIDAttr {
+				metricData.At(l).Attributes().Remove(model.InstanceLabel)
+			}
+		}
+	case pmetric.MetricDataTypeSum:
+		metricData := metric.Sum().DataPoints()
+		for l := 0; l < metricData.Len(); l++ {
+			if hasResourceServiceNameAttr {
+				metricData.At(l).Attributes().Remove(model.JobLabel)
+			}
+			if hasResourceServiceInstanceIDAttr {
+				metricData.At(l).Attributes().Remove(model.InstanceLabel)
+			}
+		}
+	case pmetric.MetricDataTypeHistogram:
+		metricData := metric.Histogram().DataPoints()
+		for l := 0; l < metricData.Len(); l++ {
+			if hasResourceServiceNameAttr {
+				metricData.At(l).Attributes().Remove(model.JobLabel)
+			}
+			if hasResourceServiceInstanceIDAttr {
+				metricData.At(l).Attributes().Remove(model.InstanceLabel)
+			}
+		}
+	case pmetric.MetricDataTypeExponentialHistogram:
+		metricData := metric.ExponentialHistogram().DataPoints()
+		for l := 0; l < metricData.Len(); l++ {
+			if hasResourceServiceNameAttr {
+				metricData.At(l).Attributes().Remove(model.JobLabel)
+			}
+			if hasResourceServiceInstanceIDAttr {
+				metricData.At(l).Attributes().Remove(model.InstanceLabel)
+			}
+		}
+	case pmetric.MetricDataTypeSummary:
+		metricData := metric.Summary().DataPoints()
+		for l := 0; l < metricData.Len(); l++ {
+			if hasResourceServiceNameAttr {
+				metricData.At(l).Attributes().Remove(model.JobLabel)
+			}
+			if hasResourceServiceInstanceIDAttr {
+				metricData.At(l).Attributes().Remove(model.InstanceLabel)
+			}
+		}
+	}
 }

--- a/processors/metricresourceattrstoattrs/metricresourcesattrstolabels_test.go
+++ b/processors/metricresourceattrstoattrs/metricresourcesattrstolabels_test.go
@@ -31,7 +31,7 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 		expectedMetricAttributes map[string]string
 		dt                       pmetric.MetricDataType
 	}{
-		"all concerned resource attrs present for sum metric: job and instance labels not added": {
+		"all concerned resource attrs present for sum metric: job and instance labels not added. existing job and instance labels are removed": {
 			inputResourceAttributes: map[string]string{
 				conventions.AttributeServiceName:       "test-service",
 				conventions.AttributeServiceInstanceID: "test-instance-id",
@@ -55,6 +55,50 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 				"scheme":                               "http",
 			},
 			dt: pmetric.MetricDataTypeSum,
+		},
+		"service name and instance resource attrs not present for sum metric: job and instance labels not added. existing job and instance labels are removed": {
+			inputResourceAttributes: map[string]string{
+				conventions.AttributeServiceName:       "test-service",
+				conventions.AttributeServiceInstanceID: "test-instance-id",
+				"port":                                 "8888",
+				"scheme":                               "http",
+			},
+			inputMetricAttributes: map[string]string{
+				"foo10":             "baz10",
+				"foo11":             "baz11",
+				model.JobLabel:      "test-metric-job-name",
+				model.InstanceLabel: "test-metric-instance",
+			},
+			expectedMetricAttributes: map[string]string{
+				"foo10":                                "baz10",
+				"foo11":                                "baz11",
+				conventions.AttributeServiceName:       "test-service",
+				conventions.AttributeServiceInstanceID: "test-instance-id",
+				"port":                                 "8888",
+				"scheme":                               "http",
+			},
+			dt: pmetric.MetricDataTypeSum,
+		},
+		"no concerned labels present: job and instance labels retained": {
+			inputResourceAttributes: map[string]string{
+				"port":   "8888",
+				"scheme": "http",
+			},
+			inputMetricAttributes: map[string]string{
+				"foo10":             "baz10",
+				"foo11":             "baz11",
+				model.JobLabel:      "test-metric-job-name",
+				model.InstanceLabel: "test-metric-instance",
+			},
+			expectedMetricAttributes: map[string]string{
+				"foo10":             "baz10",
+				"foo11":             "baz11",
+				model.JobLabel:      "test-metric-job-name",
+				model.InstanceLabel: "test-metric-instance",
+				"port":              "8888",
+				"scheme":            "http",
+			},
+			dt: pmetric.MetricDataTypeHistogram,
 		},
 		"service name and instance id resource attrs not present for sum metric: job and instance labels are added": {
 			inputResourceAttributes: map[string]string{

--- a/processors/metricresourceattrstoattrs/metricresourcesattrstolabels_test.go
+++ b/processors/metricresourceattrstoattrs/metricresourcesattrstolabels_test.go
@@ -41,8 +41,10 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 				"scheme":                               "http",
 			},
 			inputMetricAttributes: map[string]string{
-				"foo10": "baz10",
-				"foo11": "baz11",
+				"foo10":             "baz10",
+				"foo11":             "baz11",
+				model.JobLabel:      "test-metric-job-name",
+				model.InstanceLabel: "test-metric-instance",
 			},
 			expectedMetricAttributes: map[string]string{
 				"foo10":                                "baz10",
@@ -75,6 +77,29 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 			},
 			dt: pmetric.MetricDataTypeSum,
 		},
+		"service name and instance id resource attrs not present for sum metric. job and instance labels already present: job and instance labels are not added": {
+			inputResourceAttributes: map[string]string{
+				model.JobLabel:      "test-job-name",
+				model.InstanceLabel: "test-instance",
+				"port":              "8888",
+				"scheme":            "http",
+			},
+			inputMetricAttributes: map[string]string{
+				"foo10":             "baz10",
+				"foo11":             "baz11",
+				model.JobLabel:      "test-metric-job-name",
+				model.InstanceLabel: "test-metric-instance",
+			},
+			expectedMetricAttributes: map[string]string{
+				"foo10":             "baz10",
+				"foo11":             "baz11",
+				model.JobLabel:      "test-metric-job-name",
+				model.InstanceLabel: "test-metric-instance",
+				"port":              "8888",
+				"scheme":            "http",
+			},
+			dt: pmetric.MetricDataTypeSum,
+		},
 		"all concerned resource attrs present for gauge metric: job and instance labels not added": {
 			inputResourceAttributes: map[string]string{
 				conventions.AttributeServiceName:       "test-service",
@@ -84,7 +109,9 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 				"port":                                 "8888",
 			},
 			inputMetricAttributes: map[string]string{
-				"foo10": "baz10",
+				"foo10":             "baz10",
+				model.JobLabel:      "test-metric-job-name",
+				model.InstanceLabel: "test-metric-instance",
 			},
 			expectedMetricAttributes: map[string]string{
 				"foo10":                                "baz10",
@@ -103,7 +130,9 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 				"port":                                 "8888",
 			},
 			inputMetricAttributes: map[string]string{
-				"foo10": "baz10",
+				"foo10":             "baz10",
+				model.JobLabel:      "test-metric-job-name",
+				model.InstanceLabel: "test-metric-instance",
 			},
 			expectedMetricAttributes: map[string]string{
 				"foo10":                                "baz10",
@@ -122,7 +151,9 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 				"port":                                 "8888",
 			},
 			inputMetricAttributes: map[string]string{
-				"foo10": "baz10",
+				"foo10":             "baz10",
+				model.JobLabel:      "test-metric-job-name",
+				model.InstanceLabel: "test-metric-instance",
 			},
 			expectedMetricAttributes: map[string]string{
 				"foo10":                                "baz10",
@@ -141,7 +172,9 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 				"port":                                 "8888",
 			},
 			inputMetricAttributes: map[string]string{
-				"foo10": "baz10",
+				"foo10":             "baz10",
+				model.JobLabel:      "test-metric-job-name",
+				model.InstanceLabel: "test-metric-instance",
 			},
 			expectedMetricAttributes: map[string]string{
 				"foo10":                                "baz10",


### PR DESCRIPTION
## Description
`model.JobLabel` if `hasResourceServiceNameAttr` and `model.InstanceLabel` if `hasResourceServiceInstanceIDAttr`, from the metric attributes. This is because they will be added by the prometheus exporter based on serviceName and serviceInstanceId and if already present they will be duplicate and will cause an error while processing metrics.

### Testing
Wrote unit tests for the new code.

### Checklist:
- [✅  ] My changes generate no new warnings
- [✅  ] I have added tests that prove my fix is effective or that my feature works
- [ ✅ ] Any dependent changes have been merged and published in downstream modules
