### PR TITLE
fix: do not copy service.instance.id resource attr if service_instance_id already exists in the metric attrs

### DIFF
--- a/processors/metricresourceattrstoattrs/metricresourcesattrstolabels_test.go
+++ b/processors/metricresourceattrstoattrs/metricresourcesattrstolabels_test.go
@@ -228,6 +228,41 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 			},
 			dt: pmetric.MetricDataTypeSummary,
 		},
+		"service_instance_id attribute exists for gauge metric: service.instance.id resource attr not added": {
+			inputResourceAttributes: map[string]string{
+				conventions.AttributeServiceName:       "test-service",
+				conventions.AttributeServiceInstanceID: "test-instance-id",
+				"port":                                 "8888",
+			},
+			inputMetricAttributes: map[string]string{
+				"foo10":                    "baz10",
+				ocServiceInstanceIdAttrKey: "test-metric-instance-id",
+			},
+			expectedMetricAttributes: map[string]string{
+				"foo10":                          "baz10",
+				ocServiceInstanceIdAttrKey:       "test-metric-instance-id",
+				conventions.AttributeServiceName: "test-service",
+				"port":                           "8888",
+			},
+			dt: pmetric.MetricDataTypeGauge,
+		},
+		"service_instance_id does not attribute exists for gauge metric: service.instance.id resource attr added": {
+			inputResourceAttributes: map[string]string{
+				conventions.AttributeServiceName:       "test-service",
+				conventions.AttributeServiceInstanceID: "test-instance-id",
+				"port":                                 "8888",
+			},
+			inputMetricAttributes: map[string]string{
+				"foo10": "baz10",
+			},
+			expectedMetricAttributes: map[string]string{
+				"foo10":                                "baz10",
+				conventions.AttributeServiceName:       "test-service",
+				conventions.AttributeServiceInstanceID: "test-instance-id",
+				"port":                                 "8888",
+			},
+			dt: pmetric.MetricDataTypeGauge,
+		},
 	}
 
 	for name, testCase := range testCases {


### PR DESCRIPTION
## Description
Do not copy service.instance.id resource attr if service_instance_id already exists in the metric attrs. This is because the prometheus exporter will sanitize service.instance.id to become service_instance_id and hence there will be duplicate attributes and that will cause an error when scraping the prometheus metrics. This started happening after upgrading to otel collector v0.49.0

### Testing
Unit tests and local testing. 

### Checklist:
- [ ✅ ] My changes generate no new warnings
- [✅  ] I have added tests that prove my fix is effective or that my feature works

