### PR TITLE
fix: cure span logs by cutting them by half every time we make a pass.

### DIFF
--- a/exporter/kafkaexporter/jaeger_marshaler_curer_test.go
+++ b/exporter/kafkaexporter/jaeger_marshaler_curer_test.go
@@ -483,15 +483,6 @@ func TestCutSpanLogsByHalf(t *testing.T) {
 		cutSpanLogsByHalf([]jaegerproto.Log{jpl1, jpl2, jpl3, jpl4, jpl5, jpl6}))
 }
 
-func TestIntPow(t *testing.T) {
-	assert.Equal(t, 1, intPow(2, 0))
-	assert.Equal(t, 1, intPow(3, 0))
-	assert.Equal(t, 2, intPow(2, 1))
-	assert.Equal(t, 3, intPow(3, 1))
-	assert.Equal(t, 32, intPow(2, 5))
-	assert.Equal(t, 27, intPow(3, 3))
-}
-
 func createLongString(n int, s string) string {
 	var b strings.Builder
 	b.Grow(n * len(s))


### PR DESCRIPTION
## Description
There's a chance that when the spans are being converted to kafka messages, they will still be over 1MiB since the log events in the span are not cured. We fix this by removing half the log messages but maintain the distribution over time of the messages i.e in every pass drop the odd-indexed logs effectively retaining half of them.

### Testing
Unit tests

### Checklist:
- [ ✅ ] My changes generate no new warnings
- [✅  ] I have added tests that prove my fix is effective or that my feature works
- [✅  ] Any dependent changes have been merged and published in downstream modules

