### PR TITLE
Allow kafka topic creator to be disabled

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -27,5 +27,6 @@ appVersion: 0.1.0
 
 dependencies:
   - name: kafka-topic-creator
+    condition: kafka-topic-creator.enabled
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.1.9

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -221,6 +221,7 @@ hpa:
   targetCPUUtilizationPercentage: 80
 
 kafka-topic-creator:
+  enabled: true
   jobName: jaeger-spans-kafka-topic-creator
   helmHook: pre-install,pre-upgrade
   kafka:


### PR DESCRIPTION
## Description
To disable the kafka topic creator a user can set the following in `values.yaml`: 
```
kafka-topic-creator:
  enabled: false
```