### PR TITLE
fix: remove metrics whose type is "None" as they cannot be translated anyway

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/collector/service"
 	"go.uber.org/multierr"
 
+	"github.com/hypertrace/collector/processors/metricremover"
 	"github.com/hypertrace/collector/processors/metricresourceattrstoattrs"
 	"github.com/hypertrace/collector/processors/tenantidprocessor"
 )
@@ -81,6 +82,9 @@ func components() (component.Factories, error) {
 
 	mrata := metricresourceattrstoattrs.NewFactory()
 	factories.Processors[mrata.Type()] = mrata
+
+	mr := metricremover.NewFactory()
+	factories.Processors[mr.Type()] = mr
 
 	routingProcessor := routingprocessor.NewFactory()
 	factories.Processors[routingProcessor.Type()] = routingProcessor

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -171,6 +171,8 @@ configMap:
     processors:
       batch: {}
       hypertrace_metrics_resource_attrs_to_attrs: {}
+      hypertrace_metrics_remover:
+        remove_none_metric_type: true
 
     exporters:
       kafka:
@@ -211,7 +213,7 @@ configMap:
           exporters: [kafka]
         metrics:
           receivers: [otlp]
-          processors: [batch, hypertrace_metrics_resource_attrs_to_attrs]
+          processors: [hypertrace_metrics_remover, batch, hypertrace_metrics_resource_attrs_to_attrs]
           exporters: [prometheus]
 
 hpa:

--- a/processors/metricremover/README.md
+++ b/processors/metricremover/README.md
@@ -1,0 +1,6 @@
+# metricremover processor
+
+The purpose of this processor is to remove metrics based on a criteria in the config.
+
+## Config
+`remove_none_metric_type`: when set to `true`, all metrics whose type is `None` will be removed. This is important since they cannot be translated by the exporters and will error out. This usually happens when old metric APIs send metrics missing the type.

--- a/processors/metricremover/config.go
+++ b/processors/metricremover/config.go
@@ -1,0 +1,13 @@
+package metricremover
+
+import (
+	"go.opentelemetry.io/collector/config"
+)
+
+type Config struct {
+	config.ProcessorSettings `mapstructure:"-"`
+
+	// RemoveNoneMetricType enables the dropping of "None" metric types which would fail
+	// translation to prometheus metrics.
+	RemoveNoneMetricType bool `mapstructure:"remove_none_metric_type"`
+}

--- a/processors/metricremover/factory.go
+++ b/processors/metricremover/factory.go
@@ -1,0 +1,49 @@
+package metricremover
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/processor/processorhelper"
+)
+
+const (
+	typeStr = "hypertrace_metrics_remover"
+)
+
+func NewFactory() component.ProcessorFactory {
+	return component.NewProcessorFactory(
+		typeStr,
+		createDefaultConfig,
+		component.WithMetricsProcessor(createMetricsProcessor, component.StabilityLevelStable),
+	)
+}
+
+func createDefaultConfig() config.Processor {
+	return &Config{
+		ProcessorSettings: config.NewProcessorSettings(
+			config.NewComponentID(typeStr),
+		),
+	}
+}
+
+func createMetricsProcessor(
+	ctx context.Context,
+	params component.ProcessorCreateSettings,
+	cfg config.Processor,
+	nextConsumer consumer.Metrics,
+) (component.MetricsProcessor, error) {
+	pCfg := cfg.(*Config)
+	processor := &processor{
+		logger:               params.Logger,
+		removeNoneMetricType: pCfg.RemoveNoneMetricType,
+	}
+	return processorhelper.NewMetricsProcessor(
+		ctx,
+		params,
+		cfg,
+		nextConsumer,
+		processor.ProcessMetrics)
+}

--- a/processors/metricremover/factory_test.go
+++ b/processors/metricremover/factory_test.go
@@ -1,0 +1,14 @@
+package metricremover
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewFactory(t *testing.T) {
+	f := NewFactory()
+	assert.NotNil(t, f)
+
+	assert.NotNil(t, f.CreateDefaultConfig())
+}

--- a/processors/metricremover/metricremover.go
+++ b/processors/metricremover/metricremover.go
@@ -14,12 +14,16 @@ type processor struct {
 
 // ProcessMetrics implements processorhelper.ProcessMetricsFunc
 func (p *processor) ProcessMetrics(ctx context.Context, metrics pmetric.Metrics) (pmetric.Metrics, error) {
+	if !p.removeNoneMetricType {
+		return metrics, nil
+	}
+
 	rms := metrics.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
 		sms := rms.At(i).ScopeMetrics()
 		for j := 0; j < sms.Len(); j++ {
 			sms.At(j).Metrics().RemoveIf(func(m pmetric.Metric) bool {
-				return p.removeNoneMetricType && m.Type() == pmetric.MetricTypeNone
+				return m.Type() == pmetric.MetricTypeNone
 			})
 		}
 	}

--- a/processors/metricremover/metricremover_test.go
+++ b/processors/metricremover/metricremover_test.go
@@ -1,0 +1,117 @@
+package metricremover
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+func TestEmptyMetrics(t *testing.T) {
+	p := &processor{
+		logger:               zap.NewNop(),
+		removeNoneMetricType: true,
+	}
+	metrics := pmetric.NewMetrics()
+	gotMetrics, err := p.ProcessMetrics(context.Background(), metrics)
+	require.NoError(t, err)
+	assert.Equal(t, metrics, gotMetrics)
+}
+
+func TestMetricsRemoval(t *testing.T) {
+	logger := zap.NewNop()
+	testCases := map[string]struct {
+		removeNoneMetricType bool
+		inputDtArr           []pmetric.MetricType
+		expectedDtArr        []pmetric.MetricType
+	}{
+		"config enabled none metrics removed": {
+			removeNoneMetricType: true,
+			inputDtArr: []pmetric.MetricType{pmetric.MetricTypeGauge, pmetric.MetricTypeSum, pmetric.MetricTypeNone, pmetric.MetricTypeHistogram,
+				pmetric.MetricTypeExponentialHistogram, pmetric.MetricTypeNone, pmetric.MetricTypeSummary},
+			expectedDtArr: []pmetric.MetricType{pmetric.MetricTypeGauge, pmetric.MetricTypeSum, pmetric.MetricTypeHistogram,
+				pmetric.MetricTypeExponentialHistogram, pmetric.MetricTypeSummary},
+		},
+		"config disabled none metrics are not removed": {
+			removeNoneMetricType: false,
+			inputDtArr: []pmetric.MetricType{pmetric.MetricTypeGauge, pmetric.MetricTypeSum, pmetric.MetricTypeNone, pmetric.MetricTypeHistogram,
+				pmetric.MetricTypeExponentialHistogram, pmetric.MetricTypeNone, pmetric.MetricTypeSummary},
+			expectedDtArr: []pmetric.MetricType{pmetric.MetricTypeGauge, pmetric.MetricTypeSum, pmetric.MetricTypeNone, pmetric.MetricTypeHistogram,
+				pmetric.MetricTypeExponentialHistogram, pmetric.MetricTypeNone, pmetric.MetricTypeSummary},
+		},
+		"no none metrics": {
+			removeNoneMetricType: true,
+			inputDtArr: []pmetric.MetricType{pmetric.MetricTypeGauge, pmetric.MetricTypeSum, pmetric.MetricTypeHistogram,
+				pmetric.MetricTypeExponentialHistogram, pmetric.MetricTypeSummary},
+			expectedDtArr: []pmetric.MetricType{pmetric.MetricTypeGauge, pmetric.MetricTypeSum, pmetric.MetricTypeHistogram,
+				pmetric.MetricTypeExponentialHistogram, pmetric.MetricTypeSummary},
+		},
+		"only none metrics config disabled": {
+			removeNoneMetricType: false,
+			inputDtArr:           []pmetric.MetricType{pmetric.MetricTypeNone, pmetric.MetricTypeNone, pmetric.MetricTypeNone, pmetric.MetricTypeNone},
+			expectedDtArr:        []pmetric.MetricType{pmetric.MetricTypeNone, pmetric.MetricTypeNone, pmetric.MetricTypeNone, pmetric.MetricTypeNone},
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			p := &processor{
+				logger:               logger,
+				removeNoneMetricType: testCase.removeNoneMetricType,
+			}
+			metrics := generateMetricData(testCase.inputDtArr)
+			expectedMetrics := generateMetricData(testCase.expectedDtArr)
+			gotMetrics, err := p.ProcessMetrics(context.Background(), metrics)
+			require.NoError(t, err)
+			assert.Equal(t, expectedMetrics, gotMetrics)
+		})
+	}
+}
+
+// Can't add this test to the test array above since the test compares metric_arr(nil)
+// and metric_arr{} which are technically the same thing but not equal.
+func TestMetricsRemovalAllNoneMetrics(t *testing.T) {
+	p := &processor{
+		logger:               zap.NewNop(),
+		removeNoneMetricType: true,
+	}
+	dtArr := []pmetric.MetricType{pmetric.MetricTypeNone, pmetric.MetricTypeNone, pmetric.MetricTypeNone, pmetric.MetricTypeNone}
+	metrics := generateMetricData(dtArr)
+	gotMetrics, err := p.ProcessMetrics(context.Background(), metrics)
+	require.NoError(t, err)
+	assert.Equal(t, 0, gotMetrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
+}
+
+func generateMetricData(dtArr []pmetric.MetricType) pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	md.ResourceMetrics().AppendEmpty()
+	md.ResourceMetrics().At(0).ScopeMetrics().AppendEmpty()
+	for i, dt := range dtArr {
+		md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().AppendEmpty()
+		metric := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(i)
+
+		switch dt {
+		case pmetric.MetricTypeSum:
+			metric.SetEmptySum()
+			metric.Sum().DataPoints().AppendEmpty()
+		case pmetric.MetricTypeGauge:
+			metric.SetEmptyGauge()
+			metric.Gauge().DataPoints().AppendEmpty()
+		case pmetric.MetricTypeHistogram:
+			metric.SetEmptyHistogram()
+			metric.Histogram().DataPoints().AppendEmpty()
+		case pmetric.MetricTypeExponentialHistogram:
+			metric.SetEmptyExponentialHistogram()
+			metric.ExponentialHistogram().DataPoints().AppendEmpty()
+		case pmetric.MetricTypeSummary:
+			metric.SetEmptySummary()
+			metric.Summary().DataPoints().AppendEmpty()
+		case pmetric.MetricTypeNone:
+			metric.SetName("none.metric")
+		}
+	}
+
+	return md
+}

--- a/processors/metricresourceattrstoattrs/metricresourcesattrstolabels.go
+++ b/processors/metricresourceattrstoattrs/metricresourcesattrstolabels.go
@@ -80,29 +80,29 @@ func (p *processor) ProcessMetrics(ctx context.Context, metrics pmetric.Metrics)
 // applyToMetricAttributes casts out the correct struct type for the metric so that it can access the attributes map and apply a function
 // to it.
 func applyToMetricAttributes(metric pmetric.Metric, fn func(pcommon.Map)) {
-	metricDataType := metric.DataType()
+	metricDataType := metric.Type()
 	switch metricDataType {
-	case pmetric.MetricDataTypeGauge:
+	case pmetric.MetricTypeGauge:
 		metricData := metric.Gauge().DataPoints()
 		for l := 0; l < metricData.Len(); l++ {
 			fn(metricData.At(l).Attributes())
 		}
-	case pmetric.MetricDataTypeSum:
+	case pmetric.MetricTypeSum:
 		metricData := metric.Sum().DataPoints()
 		for l := 0; l < metricData.Len(); l++ {
 			fn(metricData.At(l).Attributes())
 		}
-	case pmetric.MetricDataTypeHistogram:
+	case pmetric.MetricTypeHistogram:
 		metricData := metric.Histogram().DataPoints()
 		for l := 0; l < metricData.Len(); l++ {
 			fn(metricData.At(l).Attributes())
 		}
-	case pmetric.MetricDataTypeExponentialHistogram:
+	case pmetric.MetricTypeExponentialHistogram:
 		metricData := metric.ExponentialHistogram().DataPoints()
 		for l := 0; l < metricData.Len(); l++ {
 			fn(metricData.At(l).Attributes())
 		}
-	case pmetric.MetricDataTypeSummary:
+	case pmetric.MetricTypeSummary:
 		metricData := metric.Summary().DataPoints()
 		for l := 0; l < metricData.Len(); l++ {
 			fn(metricData.At(l).Attributes())

--- a/processors/metricresourceattrstoattrs/metricresourcesattrstolabels_test.go
+++ b/processors/metricresourceattrstoattrs/metricresourcesattrstolabels_test.go
@@ -54,7 +54,7 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 				"port":                                 "8888",
 				"scheme":                               "http",
 			},
-			dt: pmetric.MetricDataTypeSum,
+			dt: pmetric.MetricTypeSum,
 		},
 		"service name and instance resource attrs not present for sum metric: job and instance labels not added. existing job and instance labels are removed": {
 			inputResourceAttributes: map[string]string{
@@ -77,7 +77,7 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 				"port":                                 "8888",
 				"scheme":                               "http",
 			},
-			dt: pmetric.MetricDataTypeSum,
+			dt: pmetric.MetricTypeSum,
 		},
 		"no concerned labels present: job and instance labels retained": {
 			inputResourceAttributes: map[string]string{
@@ -98,7 +98,7 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 				"port":              "8888",
 				"scheme":            "http",
 			},
-			dt: pmetric.MetricDataTypeHistogram,
+			dt: pmetric.MetricTypeHistogram,
 		},
 		"service name and instance id resource attrs not present for sum metric: job and instance labels are added": {
 			inputResourceAttributes: map[string]string{
@@ -119,7 +119,7 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 				"port":              "8888",
 				"scheme":            "http",
 			},
-			dt: pmetric.MetricDataTypeSum,
+			dt: pmetric.MetricTypeSum,
 		},
 		"service name and instance id resource attrs not present for sum metric. job and instance labels already present: job and instance labels are not added": {
 			inputResourceAttributes: map[string]string{
@@ -142,7 +142,7 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 				"port":              "8888",
 				"scheme":            "http",
 			},
-			dt: pmetric.MetricDataTypeSum,
+			dt: pmetric.MetricTypeSum,
 		},
 		"all concerned resource attrs present for gauge metric: job and instance labels not added": {
 			inputResourceAttributes: map[string]string{
@@ -163,7 +163,7 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 				conventions.AttributeServiceInstanceID: "test-instance-id",
 				"port":                                 "8888",
 			},
-			dt: pmetric.MetricDataTypeGauge,
+			dt: pmetric.MetricTypeGauge,
 		},
 		"all concerned resource attrs present for histogram metric: job and instance labels not added": {
 			inputResourceAttributes: map[string]string{
@@ -184,7 +184,7 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 				conventions.AttributeServiceInstanceID: "test-instance-id",
 				"port":                                 "8888",
 			},
-			dt: pmetric.MetricDataTypeHistogram,
+			dt: pmetric.MetricTypeHistogram,
 		},
 		"all concerned resource attrs present for exponential histogram metric: job and instance labels not added": {
 			inputResourceAttributes: map[string]string{
@@ -205,7 +205,7 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 				conventions.AttributeServiceInstanceID: "test-instance-id",
 				"port":                                 "8888",
 			},
-			dt: pmetric.MetricDataTypeExponentialHistogram,
+			dt: pmetric.MetricTypeExponentialHistogram,
 		},
 		"all concerned resource attrs present for summary metric: job and instance labels not added": {
 			inputResourceAttributes: map[string]string{
@@ -226,7 +226,7 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 				conventions.AttributeServiceInstanceID: "test-instance-id",
 				"port":                                 "8888",
 			},
-			dt: pmetric.MetricDataTypeSummary,
+			dt: pmetric.MetricTypeSummary,
 		},
 		"service_instance_id attribute exists for gauge metric: service.instance.id resource attr not added": {
 			inputResourceAttributes: map[string]string{
@@ -244,7 +244,7 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 				conventions.AttributeServiceName: "test-service",
 				"port":                           "8888",
 			},
-			dt: pmetric.MetricDataTypeGauge,
+			dt: pmetric.MetricTypeGauge,
 		},
 		"service_instance_id does not attribute exists for gauge metric: service.instance.id resource attr added": {
 			inputResourceAttributes: map[string]string{
@@ -261,7 +261,7 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 				conventions.AttributeServiceInstanceID: "test-instance-id",
 				"port":                                 "8888",
 			},
-			dt: pmetric.MetricDataTypeGauge,
+			dt: pmetric.MetricTypeGauge,
 		},
 	}
 
@@ -317,25 +317,25 @@ func generateMetricData(resourceAttrs map[string]string, attrs map[string]string
 		for k, v := range attrs {
 			metric.Sum().DataPoints().At(0).Attributes().PutString(k, v)
 		}
-	case pmetric.MetricDataTypeGauge:
+	case pmetric.MetricTypeGauge:
 		metric.SetEmptyGauge()
 		metric.Gauge().DataPoints().AppendEmpty()
 		for k, v := range attrs {
 			metric.Gauge().DataPoints().At(0).Attributes().PutString(k, v)
 		}
-	case pmetric.MetricDataTypeHistogram:
+	case pmetric.MetricTypeHistogram:
 		metric.SetEmptyHistogram()
 		metric.Histogram().DataPoints().AppendEmpty()
 		for k, v := range attrs {
 			metric.Histogram().DataPoints().At(0).Attributes().PutString(k, v)
 		}
-	case pmetric.MetricDataTypeExponentialHistogram:
+	case pmetric.MetricTypeExponentialHistogram:
 		metric.SetEmptyExponentialHistogram()
 		metric.ExponentialHistogram().DataPoints().AppendEmpty()
 		for k, v := range attrs {
 			metric.ExponentialHistogram().DataPoints().At(0).Attributes().PutString(k, v)
 		}
-	case pmetric.MetricDataTypeSummary:
+	case pmetric.MetricTypeSummary:
 		metric.SetEmptySummary()
 		metric.Summary().DataPoints().AppendEmpty()
 		for k, v := range attrs {
@@ -345,17 +345,17 @@ func generateMetricData(resourceAttrs map[string]string, attrs map[string]string
 	return md
 }
 
-func getMetricDataPointAttributes(metric pmetric.Metric, dt pmetric.MetricDataType) pcommon.Map {
+func getMetricDataPointAttributes(metric pmetric.Metric, dt pmetric.MetricType) pcommon.Map {
 	switch dt {
-	case pmetric.MetricDataTypeSum:
+	case pmetric.MetricTypeSum:
 		return metric.Sum().DataPoints().At(0).Attributes()
-	case pmetric.MetricDataTypeGauge:
+	case pmetric.MetricTypeGauge:
 		return metric.Gauge().DataPoints().At(0).Attributes()
-	case pmetric.MetricDataTypeHistogram:
+	case pmetric.MetricTypeHistogram:
 		return metric.Histogram().DataPoints().At(0).Attributes()
-	case pmetric.MetricDataTypeExponentialHistogram:
+	case pmetric.MetricTypeExponentialHistogram:
 		return metric.ExponentialHistogram().DataPoints().At(0).Attributes()
-	case pmetric.MetricDataTypeSummary:
+	case pmetric.MetricTypeSummary:
 		return metric.Summary().DataPoints().At(0).Attributes()
 	}
 

--- a/processors/tenantidprocessor/tenantidprocessor.go
+++ b/processors/tenantidprocessor/tenantidprocessor.go
@@ -87,31 +87,31 @@ func (p *processor) addTenantIdToMetrics(metrics pmetric.Metrics, tenantIDHeader
 			metrics := sm.Metrics()
 			for k := 0; k < metrics.Len(); k++ {
 				metric := metrics.At(k)
-				metricDataType := metric.DataType()
+				metricDataType := metric.Type()
 				switch metricDataType {
-				case pmetric.MetricDataTypeNone:
+				case pmetric.MetricTypeNone:
 					p.logger.Error("Cannot add tenantId to metric. Metric Data type not present for metric: " + metric.Name())
-				case pmetric.MetricDataTypeGauge:
+				case pmetric.MetricTypeGauge:
 					metricData := metric.Gauge().DataPoints()
 					for l := 0; l < metricData.Len(); l++ {
 						metricData.At(l).Attributes().PutString(p.tenantIDAttributeKey, tenantIDHeaderValue)
 					}
-				case pmetric.MetricDataTypeSum:
+				case pmetric.MetricTypeSum:
 					metricData := metric.Sum().DataPoints()
 					for l := 0; l < metricData.Len(); l++ {
 						metricData.At(l).Attributes().PutString(p.tenantIDAttributeKey, tenantIDHeaderValue)
 					}
-				case pmetric.MetricDataTypeHistogram:
+				case pmetric.MetricTypeHistogram:
 					metricData := metric.Histogram().DataPoints()
 					for l := 0; l < metricData.Len(); l++ {
 						metricData.At(l).Attributes().PutString(p.tenantIDAttributeKey, tenantIDHeaderValue)
 					}
-				case pmetric.MetricDataTypeExponentialHistogram:
+				case pmetric.MetricTypeExponentialHistogram:
 					metricData := metric.ExponentialHistogram().DataPoints()
 					for l := 0; l < metricData.Len(); l++ {
 						metricData.At(l).Attributes().PutString(p.tenantIDAttributeKey, tenantIDHeaderValue)
 					}
-				case pmetric.MetricDataTypeSummary:
+				case pmetric.MetricTypeSummary:
 					metricData := metric.Summary().DataPoints()
 					for l := 0; l < metricData.Len(); l++ {
 						metricData.At(l).Attributes().PutString(p.tenantIDAttributeKey, tenantIDHeaderValue)

--- a/processors/tenantidprocessor/tenantidprocessor_test.go
+++ b/processors/tenantidprocessor/tenantidprocessor_test.go
@@ -388,8 +388,8 @@ func assertTenantAttributeExists(t *testing.T, trace ptrace.Traces, tenantAttrKe
 		tenantAttr, ok := rs.Resource().Attributes().Get(tenantAttrKey)
 		require.True(t, ok)
 		numOfTenantAttrs++
-		assert.Equal(t, pcommon.ValueTypeString, tenantAttr.Type())
-		assert.Equal(t, tenantID, tenantAttr.StringVal())
+		assert.Equal(t, pcommon.ValueTypeStr, tenantAttr.Type())
+		assert.Equal(t, tenantID, tenantAttr.Str())
 	}
 	return numOfTenantAttrs
 }


### PR DESCRIPTION
## Description
Old otel metric APIs are not setting the metric type and this leads to an error when translating the metric to a prometheus metric. This adds a processor which removes metrics whose type is not set.
The error logged that we are fixing:
```
2022-11-02T21:07:38.801Z        error   prometheusexporter/accumulator.go:105   failed to translate metric      {"kind": "exporter", "data_type": "metrics", "name": "prometheus", "data_type": "\u0000", "metric_name": "traceableagent.heartbeat"}
github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter.(*lastValueAccumulator).addMetric
        /go/src/github.com/hypertrace/collector/exporter/prometheusexporter/accumulator.go:105
github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter.(*lastValueAccumulator).Accumulate
        /go/src/github.com/hypertrace/collector/exporter/prometheusexporter/accumulator.go:82
github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter.(*collector).processMetrics
        /go/src/github.com/hypertrace/collector/exporter/prometheusexporter/collector.go:66
github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter.(*prometheusExporter).ConsumeMetrics
        /go/src/github.com/hypertrace/collector/exporter/prometheusexporter/prometheus.go:94
go.opentelemetry.io/collector/exporter/exporterhelper.(*metricsRequest).Export
        /go/pkg/mod/go.opentelemetry.io/collector@v0.61.0/exporter/exporterhelper/metrics.go:65
go.opentelemetry.io/collector/exporter/exporterhelper.(*timeoutSender).send
        /go/pkg/mod/go.opentelemetry.io/collector@v0.61.0/exporter/exporterhelper/common.go:203
go.opentelemetry.io/collector/exporter/exporterhelper.(*retrySender).send
        /go/pkg/mod/go.opentelemetry.io/collector@v0.61.0/exporter/exporterhelper/queued_retry.go:359
go.opentelemetry.io/collector/exporter/exporterhelper.(*metricsSenderWithObservability).send
        /go/pkg/mod/go.opentelemetry.io/collector@v0.61.0/exporter/exporterhelper/metrics.go:133
go.opentelemetry.io/collector/exporter/exporterhelper.(*queuedRetrySender).send
        /go/pkg/mod/go.opentelemetry.io/collector@v0.61.0/exporter/exporterhelper/queued_retry.go:295
go.opentelemetry.io/collector/exporter/exporterhelper.NewMetricsExporter.func2
        /go/pkg/mod/go.opentelemetry.io/collector@v0.61.0/exporter/exporterhelper/metrics.go:113
go.opentelemetry.io/collector/consumer.ConsumeMetricsFunc.ConsumeMetrics
        /go/pkg/mod/go.opentelemetry.io/collector@v0.61.0/consumer/metrics.go:36
go.opentelemetry.io/collector/processor/batchprocessor.(*batchMetrics).export
        /go/pkg/mod/go.opentelemetry.io/collector@v0.61.0/processor/batchprocessor/batch_processor.go:297
go.opentelemetry.io/collector/processor/batchprocessor.(*batchProcessor).sendItems
        /go/pkg/mod/go.opentelemetry.io/collector@v0.61.0/processor/batchprocessor/batch_processor.go:176
go.opentelemetry.io/collector/processor/batchprocessor.(*batchProcessor).startProcessingCycle
        /go/pkg/mod/go.opentelemetry.io/collector@v0.61.0/processor/batchprocessor/batch_processor.go:143
```

### Testing
- Unit tests
- Verified in a local deployment

### Checklist:
- [✅  ] My changes generate no new warnings
- [ ✅ ] I have added tests that prove my fix is effective or that my feature works

