### PR TITLE
feat: criteria based span counter

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/hypertrace/collector/processors/metricremover"
 	"github.com/hypertrace/collector/processors/metricresourceattrstoattrs"
+	"github.com/hypertrace/collector/processors/spancounter"
 	"github.com/hypertrace/collector/processors/tenantidprocessor"
 )
 
@@ -89,6 +90,9 @@ func components() (component.Factories, error) {
 	routingProcessor := routingprocessor.NewFactory()
 	factories.Processors[routingProcessor.Type()] = routingProcessor
 
+	sc := spancounter.NewFactory()
+	factories.Processors[sc.Type()] = sc
+
 	fef := fileexporter.NewFactory()
 	factories.Exporters[fef.Type()] = fef
 
@@ -112,6 +116,7 @@ func run(settings service.CollectorSettings) error {
 
 func registerMetricViews() error {
 	views := tenantidprocessor.MetricViews()
+	views = append(views, spancounter.MetricViews()...)
 	return view.Register(views...)
 }
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -173,6 +173,21 @@ configMap:
       hypertrace_metrics_resource_attrs_to_attrs: {}
       hypertrace_metrics_remover:
         remove_none_metric_type: true
+      # Example of hypertrace_spancounter config
+      #
+      # hypertrace_spancounter:
+      #   tenant_configs:
+      #     - tenant_id: foo-bar-baz
+      #       service_configs:
+      #         - service_name: example-service
+      #           span_configs:
+      #             - label: example-service-attr-rules
+      #               span_attributes:
+      #                 - key: rpc.service
+      #                   value: config.service.v1.AttributeConfigService
+      #                 - key: rpc.method
+      #                   value: GetAttributeRules
+      hypertrace_spancounter: {}
 
     exporters:
       kafka:

--- a/processors/spancounter/config.go
+++ b/processors/spancounter/config.go
@@ -1,0 +1,34 @@
+package spancounter
+
+import (
+	"go.opentelemetry.io/collector/config"
+)
+
+type Config struct {
+	config.ProcessorSettings `mapstructure:"-"`
+	// TenantIDAttributeKey defines span attribute key for tenant. Default tenant-id.
+	TenantIDAttributeKey string         `mapstructure:"tenant_id_attribute_key"`
+	TenantConfigs        []TenantConfig `mapstructure:"tenant_configs"`
+}
+
+type TenantConfig struct {
+	TenantId       string          `mapstructure:"tenant_id"`
+	ServiceConfigs []ServiceConfig `mapstructure:"service_configs"`
+}
+
+type ServiceConfig struct {
+	ServiceName string       `mapstructure:"service_name"`
+	SpanConfigs []SpanConfig `mapstructure:"span_configs"`
+}
+
+type SpanConfig struct {
+	// This is used to identify matches in the metrics. It should be unique.
+	Label          string          `mapstructure:"label"`
+	SpanName       string          `mapstructure:"span_name"`
+	SpanAttributes []SpanAttribute `mapstructure:"span_attributes"`
+}
+
+type SpanAttribute struct {
+	Key   string `mapstructure:"key"`
+	Value string `mapstructure:"value"`
+}

--- a/processors/spancounter/factory.go
+++ b/processors/spancounter/factory.go
@@ -1,0 +1,66 @@
+package spancounter
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/processor/processorhelper"
+	"go.uber.org/zap"
+)
+
+const (
+	typeStr = "hypertrace_spancounter"
+)
+
+// NewFactory creates a factory for the spancounter processor.
+func NewFactory() component.ProcessorFactory {
+	return component.NewProcessorFactory(
+		typeStr,
+		createDefaultConfig,
+		component.WithTracesProcessor(createTracesProcessor, component.StabilityLevelStable),
+	)
+}
+
+func createDefaultConfig() config.Processor {
+	return &Config{
+		ProcessorSettings: config.NewProcessorSettings(
+			config.NewComponentID(typeStr),
+		),
+		TenantIDAttributeKey: defaultTenantIDAttributeKey,
+	}
+}
+
+func createTracesProcessor(
+	ctx context.Context,
+	params component.ProcessorCreateSettings,
+	cfg config.Processor,
+	nextConsumer consumer.Traces,
+) (component.TracesProcessor, error) {
+	pCfg := cfg.(*Config)
+	addUniqueLabelsToSpanConfigs(pCfg)
+	params.Logger.Info("Criteria based span counter processor config", zap.Any("config", pCfg))
+	processor := newProcessor(params.Logger, pCfg)
+	return processorhelper.NewTracesProcessor(
+		ctx,
+		params,
+		cfg,
+		nextConsumer,
+		processor.ProcessTraces)
+}
+
+// addUniqueLabelsToSpanConfigs adds unique labels to the span configs so that the span count metrics are uniquely identified
+// and we can match it to the matching span config.
+func addUniqueLabelsToSpanConfigs(c *Config) {
+	for tenantIndex, tc := range c.TenantConfigs {
+		for serviceIndex, sc := range tc.ServiceConfigs {
+			for spanIndex, spanConfig := range sc.SpanConfigs {
+				if len(spanConfig.Label) == 0 {
+					c.TenantConfigs[tenantIndex].ServiceConfigs[serviceIndex].SpanConfigs[spanIndex].Label = uuid.NewString()
+				}
+			}
+		}
+	}
+}

--- a/processors/spancounter/factory_test.go
+++ b/processors/spancounter/factory_test.go
@@ -1,0 +1,49 @@
+package spancounter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateDefaultConfig(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	assert.Equal(t, defaultTenantIDAttributeKey, cfg.TenantIDAttributeKey)
+}
+
+func TestAddUniqueLabelsToSpanConfigs(t *testing.T) {
+	c := &Config{
+		TenantConfigs: []TenantConfig{
+			{
+				TenantId: "example-tenant",
+				ServiceConfigs: []ServiceConfig{
+					{
+						ServiceName: "example-service",
+						SpanConfigs: []SpanConfig{
+							{
+								Label:    "example-label",
+								SpanName: "span-1",
+							},
+							{
+								SpanName: "span-2",
+							},
+						},
+					},
+					{
+						ServiceName: "example-service-2",
+						SpanConfigs: []SpanConfig{
+							{
+								SpanName: "span-20",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	addUniqueLabelsToSpanConfigs(c)
+	assert.Equal(t, "example-label", c.TenantConfigs[0].ServiceConfigs[0].SpanConfigs[0].Label)
+	assert.Greater(t, len(c.TenantConfigs[0].ServiceConfigs[0].SpanConfigs[1].Label), 0)
+	assert.Greater(t, len(c.TenantConfigs[0].ServiceConfigs[1].SpanConfigs[0].Label), 0)
+}

--- a/processors/spancounter/metrics.go
+++ b/processors/spancounter/metrics.go
@@ -1,0 +1,29 @@
+package spancounter
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var (
+	tagSpanCriteriaLabel       = tag.MustNewKey("span-criteria-label")
+	statCriteriaBasedSpanCount = stats.Int64("criteria_span_count", "Number of spans received from a tenant that match a certain criteria", stats.UnitDimensionless)
+)
+
+// MetricViews returns the metrics views for spancounter processor.
+func MetricViews() []*view.View {
+	tags := []tag.Key{tagSpanCriteriaLabel}
+
+	viewCriteriaBasedSpanCount := &view.View{
+		Name:        statCriteriaBasedSpanCount.Name(),
+		Description: statCriteriaBasedSpanCount.Description(),
+		Measure:     statCriteriaBasedSpanCount,
+		Aggregation: view.Sum(),
+		TagKeys:     tags,
+	}
+
+	return []*view.View{
+		viewCriteriaBasedSpanCount,
+	}
+}

--- a/processors/spancounter/spancounterprocessor.go
+++ b/processors/spancounter/spancounterprocessor.go
@@ -1,0 +1,128 @@
+package spancounter
+
+import (
+	"context"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	"go.uber.org/zap"
+)
+
+const defaultTenantIDAttributeKey string = "tenant-id"
+
+type processor struct {
+	logger *zap.Logger
+	// The levels are tenant > service > span config. So this is a map of tenant ids
+	// to maps of service names to span configs
+	tenantIDAttributeKey string
+	tenantsMap           map[string]map[string][]SpanConfig
+}
+
+func newProcessor(logger *zap.Logger, cfg *Config) *processor {
+	tm := createTenantsMap(cfg)
+	tenantIDAttributeKey := defaultTenantIDAttributeKey
+	if len(cfg.TenantIDAttributeKey) != 0 {
+		tenantIDAttributeKey = cfg.TenantIDAttributeKey
+	}
+	processor := &processor{
+		logger:               logger,
+		tenantIDAttributeKey: tenantIDAttributeKey,
+		tenantsMap:           tm,
+	}
+
+	return processor
+}
+
+func createTenantsMap(cfg *Config) map[string]map[string][]SpanConfig {
+	m := make(map[string]map[string][]SpanConfig, len(cfg.TenantConfigs))
+	for _, tc := range cfg.TenantConfigs {
+		if len(tc.TenantId) == 0 { // skip empty tenant id
+			continue
+		}
+		sm := make(map[string][]SpanConfig, len(tc.ServiceConfigs))
+		for _, sc := range tc.ServiceConfigs {
+			if len(sc.ServiceName) == 0 { // skip empty service name
+				continue
+			}
+
+			sm[sc.ServiceName] = sc.SpanConfigs
+		}
+
+		m[tc.TenantId] = sm
+	}
+	return m
+}
+
+// ProcessTraces implements processorhelper.ProcessTracesFunc
+func (p *processor) ProcessTraces(ctx context.Context, traces ptrace.Traces) (ptrace.Traces, error) {
+	rss := traces.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		rs := rss.At(i)
+		tenantIdVal, found := rs.Resource().Attributes().Get(p.tenantIDAttributeKey)
+		tenantId := tenantIdVal.Str()
+		if !found || len(tenantId) == 0 {
+			continue
+		}
+		servicesMap, found := p.tenantsMap[tenantId]
+		if !found || len(servicesMap) == 0 {
+			continue
+		}
+
+		serviceNameVal, found := rs.Resource().Attributes().Get(conventions.AttributeServiceName)
+		serviceName := serviceNameVal.Str()
+		if !found || len(serviceName) == 0 {
+			continue
+		}
+
+		spanConfigs, found := servicesMap[serviceName]
+		if !found || len(spanConfigs) == 0 {
+			continue
+		}
+
+		for _, sc := range spanConfigs {
+			spanCount := 0
+			for j := 0; j < rs.ScopeSpans().Len(); j++ {
+				scss := rs.ScopeSpans().At(j)
+				for k := 0; k < scss.Spans().Len(); k++ {
+					span := scss.Spans().At(k)
+					if spanMatchesConfig(span, sc) {
+						spanCount++
+					}
+				}
+			}
+
+			if spanCount > 0 {
+				ctx, _ = tag.New(ctx,
+					tag.Insert(tagSpanCriteriaLabel, sc.Label))
+				stats.Record(ctx, statCriteriaBasedSpanCount.M(int64(spanCount)))
+			}
+		}
+	}
+
+	return traces, nil
+}
+
+func spanMatchesConfig(span ptrace.Span, spanConfig SpanConfig) bool {
+	// If span name is configured, it needs to match. If not configured, skip this check.
+	if len(spanConfig.SpanName) != 0 && span.Name() != spanConfig.SpanName {
+		return false
+	}
+
+	for _, attr := range spanConfig.SpanAttributes {
+		v, ok := span.Attributes().Get(attr.Key)
+		if !ok {
+			return false
+		}
+
+		// empty value means we are just checking for the presence of attribute.
+		if len(attr.Value) == 0 || attr.Value == v.Str() {
+			continue
+		} else {
+			return false
+		}
+	}
+
+	return true
+}

--- a/processors/spancounter/spancounterprocessor.go
+++ b/processors/spancounter/spancounterprocessor.go
@@ -55,8 +55,11 @@ func createTenantsMap(cfg *Config) map[string]map[string][]SpanConfig {
 	return m
 }
 
-// ProcessTraces implements processorhelper.ProcessTracesFunc
 func (p *processor) ProcessTraces(ctx context.Context, traces ptrace.Traces) (ptrace.Traces, error) {
+	if len(p.tenantsMap) == 0 {
+		return traces, nil
+	}
+
 	rss := traces.ResourceSpans()
 	for i := 0; i < rss.Len(); i++ {
 		rs := rss.At(i)

--- a/processors/spancounter/spancounterprocessor_test.go
+++ b/processors/spancounter/spancounterprocessor_test.go
@@ -1,0 +1,85 @@
+package spancounter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+)
+
+func TestNewProcessor(t *testing.T) {
+	logger := zap.NewNop()
+	c := &Config{
+		TenantConfigs: []TenantConfig{
+			{
+				ServiceConfigs: []ServiceConfig{
+					{
+						ServiceName: "example-service",
+						SpanConfigs: []SpanConfig{
+							{
+								Label:    "example-label",
+								SpanName: "span-1",
+							},
+							{
+								SpanName: "span-2",
+							},
+						},
+					},
+					{
+						ServiceName: "example-service-2",
+						SpanConfigs: []SpanConfig{
+							{
+								SpanName: "span-20",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	p := newProcessor(logger, c)
+	assert.Equal(t, defaultTenantIDAttributeKey, p.tenantIDAttributeKey)
+
+	c.TenantIDAttributeKey = "custom-tenant-id"
+	p = newProcessor(logger, c)
+	assert.Equal(t, "custom-tenant-id", p.tenantIDAttributeKey)
+}
+
+func TestSpanMatchesConfig(t *testing.T) {
+	span := ptrace.NewSpan()
+	span.SetName("span1")
+	span.Attributes().PutString("a1", "v1")
+	span.Attributes().PutString("a2", "v2")
+
+	sc := SpanConfig{SpanName: "span1"}
+	assert.True(t, spanMatchesConfig(span, sc))
+
+	sc = SpanConfig{SpanName: "span2"}
+	assert.False(t, spanMatchesConfig(span, sc))
+
+	sc = SpanConfig{
+		SpanName: "span1",
+		SpanAttributes: []SpanAttribute{
+			{Key: "a1"},
+		},
+	}
+	assert.True(t, spanMatchesConfig(span, sc))
+
+	sc = SpanConfig{
+		SpanName: "span1",
+		SpanAttributes: []SpanAttribute{
+			{Key: "a1", Value: "v1"},
+		},
+	}
+	assert.True(t, spanMatchesConfig(span, sc))
+
+	sc = SpanConfig{
+		SpanName: "span1",
+		SpanAttributes: []SpanAttribute{
+			{Key: "a1", Value: "v3"},
+		},
+	}
+	assert.False(t, spanMatchesConfig(span, sc))
+}


### PR DESCRIPTION
## Description

Adds a processor that creates a metric for spans count based on matching certain conditions. The purpose is to be able to debug whether spans that match a certain criteria make it to the platform and how many of them make it. Here's an example of the processor config:
```
hypertrace_spancounter:
  tenant_configs:
    - tenant_id: foo-bar-baz
      service_configs:
        - service_name: test-service
          span_configs:
            - label: test-service-attr-rules-spans
              span_attributes:
                - key: rpc.service
                  value: config.service.v1,ConfigService
                - key: rpc.method
                  value: GetAttributeRules
```
When the collector receives spans that match the tenant, service and span attributes above, it will add the count of those spans to the otelcol_criteria_span_count metric.


### Testing
Local testing and unit testing.

### Checklist:
- [✅  ] My changes generate no new warnings
- [ ✅ ] I have added tests that prove my fix is effective or that my feature works

