### PR TITLE
Add rate limiter processor

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -121,6 +121,7 @@ func run(settings service.CollectorSettings) error {
 func registerMetricViews() error {
 	views := tenantidprocessor.MetricViews()
 	views = append(views, spancounter.MetricViews()...)
+	views = append(views, ratelimiter.MetricViews()...)
 	return view.Register(views...)
 }
 

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor"
 	"log"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter"
@@ -10,6 +9,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
@@ -29,6 +29,7 @@ import (
 
 	"github.com/hypertrace/collector/processors/metricremover"
 	"github.com/hypertrace/collector/processors/metricresourceattrstoattrs"
+	"github.com/hypertrace/collector/processors/ratelimiter"
 	"github.com/hypertrace/collector/processors/tenantidprocessor"
 )
 
@@ -79,6 +80,9 @@ func components() (component.Factories, error) {
 
 	tidpf := tenantidprocessor.NewFactory()
 	factories.Processors[tidpf.Type()] = tidpf
+
+	rlpf := ratelimiter.NewFactory()
+	factories.Processors[rlpf.Type()] = rlpf
 
 	mrata := metricresourceattrstoattrs.NewFactory()
 	factories.Processors[mrata.Type()] = mrata

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	go.uber.org/multierr v1.8.0
 	go.uber.org/zap v1.23.0
 	google.golang.org/grpc v1.49.0
+	github.com/envoyproxy/go-control-plane v0.10.3
 )
 
 require (
@@ -63,7 +64,6 @@ require (
 	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
-	github.com/envoyproxy/go-control-plane v0.10.3 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.6.7 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.18
 
 require (
 	github.com/apache/thrift v0.17.0
+	github.com/envoyproxy/go-control-plane v0.10.3
+	github.com/google/uuid v1.3.0
 	github.com/jaegertracing/jaeger v1.38.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.61.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.61.0
@@ -17,7 +19,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.61.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.61.0
 	github.com/prometheus/common v0.37.0
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.1
 	go.opencensus.io v0.23.0
 	go.opentelemetry.io/collector v0.61.0
 	go.opentelemetry.io/collector/pdata v0.61.0
@@ -26,7 +28,6 @@ require (
 	go.uber.org/multierr v1.8.0
 	go.uber.org/zap v1.23.0
 	google.golang.org/grpc v1.49.0
-	github.com/envoyproxy/go-control-plane v0.10.3
 )
 
 require (
@@ -90,7 +91,6 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.1.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
 	github.com/gophercloud/gophercloud v0.25.0 // indirect
@@ -183,6 +183,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.12.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/subosito/gotenv v1.3.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.10 // indirect
 	github.com/tklauser/numcpus v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -786,6 +786,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -796,6 +798,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stvp/go-udp-testing v0.0.0-20201019212854-469649b16807/go.mod h1:7jxmlfBCDBXRzr0eAQJ48XC1hBu1np4CS5+cHEYfwpc=
 github.com/subosito/gotenv v1.3.0 h1:mjC+YW8QpAdXibNi+vNWgzmgBH4+5l5dCXv8cNysBLI=
 github.com/subosito/gotenv v1.3.0/go.mod h1:YzJjq/33h7nrwdY+iHMhEOEEbW0ovIz0tB6t6PwAXzs=

--- a/go.sum
+++ b/go.sum
@@ -784,7 +784,6 @@ github.com/spf13/viper v1.12.0/go.mod h1:b6COn30jlNxbm/V2IqWiNWkJ+vZNiMNksliPCiu
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -796,7 +795,6 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=

--- a/processors/ratelimiter/config.go
+++ b/processors/ratelimiter/config.go
@@ -1,0 +1,25 @@
+package ratelimiter
+
+import (
+	"go.opentelemetry.io/collector/config"
+)
+
+// Config defines config for ratelimit processor.
+// The processor calls rate limit service for group of spans.
+// The processor either drops or forwards data based on rate limit response.
+// The tenant ID header is obtained from the context object.
+// The processor run immediately after tenantId processor
+type Config struct {
+	config.ProcessorSettings `mapstructure:"-"`
+
+	// RateLimitServiceHost defines host where rate limiter service is running default "localhost".
+	RateLimitServiceHost string `mapstructure:"service_host"`
+	// RateLimitServicePort defines port where rate limiter service is running. Default 8081.
+	RateLimitServicePort uint16 `mapstructure:"service_port"`
+	//Domain  rate limit configuration domain to query. Default collector
+	Domain string `mapstructure:"domain"`
+	// DomainSoftRateLimitThreshold represents the threshold where soft limit window started.
+	DomainSoftRateLimitThreshold uint32 `mapstructure:"domain_soft_limit_threshold"`
+	// TenantIDHeaderName defines tenant HTTP header name. Default x-tenant-id.
+	TenantIDHeaderName string `mapstructure:"header_name"`
+}

--- a/processors/ratelimiter/config.go
+++ b/processors/ratelimiter/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	// DomainSoftRateLimitThreshold represents the threshold where soft limit window started.
 	DomainSoftRateLimitThreshold uint32 `mapstructure:"domain_soft_limit_threshold"`
 	// TenantIDHeaderName defines tenant HTTP header name. Default x-tenant-id.
-	TenantIDHeaderName string `mapstructure:"header_name"`
+	TenantIDHeaderName string `mapstructure:"tenant_id_header_name"`
 	// Timeout in millis for grpc call.
 	RateLimitServiceTimeoutMillis uint32 `mapstructure:"timeout_millis"`
 }

--- a/processors/ratelimiter/config.go
+++ b/processors/ratelimiter/config.go
@@ -12,10 +12,10 @@ import (
 type Config struct {
 	config.ProcessorSettings `mapstructure:"-"`
 
-	// RateLimitServiceHost defines host where rate limiter service is running default "localhost".
-	RateLimitServiceHost string `mapstructure:"service_host"`
-	// RateLimitServicePort defines port where rate limiter service is running. Default 8081.
-	RateLimitServicePort uint16 `mapstructure:"service_port"`
+	// ServiceHost defines host where rate limiter service is running default "localhost".
+	ServiceHost string `mapstructure:"service_host"`
+	// ServicePort defines port where rate limiter service is running. Default 8081.
+	ServicePort uint16 `mapstructure:"service_port"`
 	//Domain  rate limit configuration domain to query. Default collector
 	Domain string `mapstructure:"domain"`
 	// DomainSoftRateLimitThreshold represents the threshold where soft limit window started.
@@ -23,5 +23,5 @@ type Config struct {
 	// TenantIDHeaderName defines tenant HTTP header name. Default x-tenant-id.
 	TenantIDHeaderName string `mapstructure:"tenant_id_header_name"`
 	// Timeout in millis for grpc call.
-	RateLimitServiceTimeoutMillis uint32 `mapstructure:"timeout_millis"`
+	TimeoutMillis uint32 `mapstructure:"timeout_millis"`
 }

--- a/processors/ratelimiter/config.go
+++ b/processors/ratelimiter/config.go
@@ -22,4 +22,6 @@ type Config struct {
 	DomainSoftRateLimitThreshold uint32 `mapstructure:"domain_soft_limit_threshold"`
 	// TenantIDHeaderName defines tenant HTTP header name. Default x-tenant-id.
 	TenantIDHeaderName string `mapstructure:"header_name"`
+	// Timeout in millis for grpc call.
+	RateLimitServiceTimeoutMillis uint32 `mapstructure:"timeout_millis"`
 }

--- a/processors/ratelimiter/config_test.go
+++ b/processors/ratelimiter/config_test.go
@@ -27,4 +27,5 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, "localhost", tIDcfg.RateLimitServiceHost)
 	assert.Equal(t, uint16(8081), tIDcfg.RateLimitServicePort)
 	assert.Equal(t, uint32(10), tIDcfg.DomainSoftRateLimitThreshold)
+	assert.Equal(t, uint32(10), tIDcfg.RateLimitServiceTimeoutMillis)
 }

--- a/processors/ratelimiter/config_test.go
+++ b/processors/ratelimiter/config_test.go
@@ -24,8 +24,8 @@ func TestLoadConfig(t *testing.T) {
 	tIDcfg := cfg.Processors[config.NewComponentID(typeStr)].(*Config)
 	assert.Equal(t, "header-tenant", tIDcfg.TenantIDHeaderName)
 	assert.Equal(t, "app", tIDcfg.Domain)
-	assert.Equal(t, "localhost", tIDcfg.RateLimitServiceHost)
-	assert.Equal(t, uint16(8081), tIDcfg.RateLimitServicePort)
+	assert.Equal(t, "localhost", tIDcfg.ServiceHost)
+	assert.Equal(t, uint16(8081), tIDcfg.ServicePort)
 	assert.Equal(t, uint32(10), tIDcfg.DomainSoftRateLimitThreshold)
-	assert.Equal(t, uint32(10), tIDcfg.RateLimitServiceTimeoutMillis)
+	assert.Equal(t, uint32(10), tIDcfg.TimeoutMillis)
 }

--- a/processors/ratelimiter/config_test.go
+++ b/processors/ratelimiter/config_test.go
@@ -1,0 +1,30 @@
+package ratelimiter
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/service/servicetest"
+)
+
+func TestLoadConfig(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	assert.NoError(t, err)
+
+	factories.Processors[typeStr] = NewFactory()
+
+	cfg, err := servicetest.LoadConfig(path.Join(".", "testdata", "config.yml"), factories)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	tIDcfg := cfg.Processors[config.NewComponentID(typeStr)].(*Config)
+	assert.Equal(t, "header-tenant", tIDcfg.TenantIDHeaderName)
+	assert.Equal(t, "app", tIDcfg.Domain)
+	assert.Equal(t, "localhost", tIDcfg.RateLimitServiceHost)
+	assert.Equal(t, uint16(8081), tIDcfg.RateLimitServicePort)
+	assert.Equal(t, uint32(10), tIDcfg.DomainSoftRateLimitThreshold)
+}

--- a/processors/ratelimiter/factory.go
+++ b/processors/ratelimiter/factory.go
@@ -70,7 +70,8 @@ func createTraceProcessor(
 	return processor, nil
 }
 
-func getRateLimitServiceClient(ctx context.Context, serviceHost string, servicePort uint16, timeoutMillis uint32, params component.ProcessorCreateSettings) (pb.RateLimitServiceClient, error) {
+func getRateLimitServiceClient(ctx context.Context, serviceHost string, servicePort uint16,
+	timeoutMillis uint32, params component.ProcessorCreateSettings) (pb.RateLimitServiceClient, error) {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, time.Millisecond*time.Duration(timeoutMillis))
 	defer cancel()
 	var err error

--- a/processors/ratelimiter/factory.go
+++ b/processors/ratelimiter/factory.go
@@ -1,0 +1,88 @@
+package ratelimiter
+
+import (
+	"context"
+	"net"
+	"strconv"
+
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/processor/processorhelper"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const (
+	typeStr                         = "hypertrace_ratelimiter"
+	defaultServiceHost              = "127.0.0.1"
+	defaultServicePort              = uint16(8081)
+	defaultDomain                   = "collector"
+	defaultDomainSoftLimitThreshold = uint32(100000)
+	defaultHeaderName               = "x-tenant-id"
+)
+
+// NewFactory creates a factory for the ratelimit processor.
+func NewFactory() component.ProcessorFactory {
+	return component.NewProcessorFactory(
+		typeStr,
+		createDefaultConfig,
+		component.WithTracesProcessor(createTraceProcessor, component.StabilityLevelStable),
+	)
+}
+
+func createDefaultConfig() config.Processor {
+	return &Config{
+		ProcessorSettings: config.NewProcessorSettings(
+			config.NewComponentID(typeStr),
+		),
+		RateLimitServiceHost:         defaultServiceHost,
+		RateLimitServicePort:         defaultServicePort,
+		Domain:                       defaultDomain,
+		DomainSoftRateLimitThreshold: defaultDomainSoftLimitThreshold,
+		TenantIDHeaderName:           defaultHeaderName,
+	}
+}
+
+func createTraceProcessor(
+	ctx context.Context,
+	params component.ProcessorCreateSettings,
+	cfg config.Processor,
+	nextConsumer consumer.Traces,
+) (component.TracesProcessor, error) {
+	pCfg := cfg.(*Config)
+	rateLimitServiceClient, err := getRateLimitServiceClient(pCfg.RateLimitServiceHost, pCfg.RateLimitServicePort, params)
+	if err != nil {
+		params.Logger.Error("failed to connect to rate limit service ", zap.Error(err))
+		return nil, err
+	}
+	processor := &processor{
+		rateLimitServiceClient:   rateLimitServiceClient,
+		domain:                   pCfg.Domain,
+		domainSoftLimitThreshold: pCfg.DomainSoftRateLimitThreshold,
+		logger:                   params.Logger,
+	}
+	return processorhelper.NewTracesProcessor(
+		ctx,
+		params,
+		cfg,
+		nextConsumer,
+		processor.ProcessTraces)
+}
+
+func getRateLimitServiceClient(serviceHost string, servicePort uint16, params component.ProcessorCreateSettings) (pb.RateLimitServiceClient, error) {
+	var opts []grpc.DialOption
+	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	var err error
+	var conn *grpc.ClientConn
+	dialString := net.JoinHostPort(serviceHost, strconv.Itoa(int(servicePort)))
+	params.Logger.Info("connecting to rate limit service %s " + dialString)
+	conn, err = grpc.Dial(dialString, opts...)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	return pb.NewRateLimitServiceClient(conn), nil
+}

--- a/processors/ratelimiter/factory.go
+++ b/processors/ratelimiter/factory.go
@@ -39,12 +39,12 @@ func createDefaultConfig() config.Processor {
 		ProcessorSettings: config.NewProcessorSettings(
 			config.NewComponentID(typeStr),
 		),
-		RateLimitServiceHost:          defaultServiceHost,
-		RateLimitServicePort:          defaultServicePort,
-		Domain:                        defaultDomain,
-		DomainSoftRateLimitThreshold:  defaultDomainSoftLimitThreshold,
-		TenantIDHeaderName:            defaultHeaderName,
-		RateLimitServiceTimeoutMillis: defaultTimeoutMillis,
+		ServiceHost:                  defaultServiceHost,
+		ServicePort:                  defaultServicePort,
+		Domain:                       defaultDomain,
+		DomainSoftRateLimitThreshold: defaultDomainSoftLimitThreshold,
+		TenantIDHeaderName:           defaultHeaderName,
+		TimeoutMillis:                defaultTimeoutMillis,
 	}
 }
 
@@ -55,7 +55,7 @@ func createTraceProcessor(
 	nextConsumer consumer.Traces,
 ) (component.TracesProcessor, error) {
 	pCfg := cfg.(*Config)
-	rateLimitServiceClient, err := getRateLimitServiceClient(ctx, pCfg.RateLimitServiceHost, pCfg.RateLimitServicePort, pCfg.RateLimitServiceTimeoutMillis, params)
+	rateLimitServiceClient, err := getRateLimitServiceClient(ctx, pCfg.ServiceHost, pCfg.ServicePort, pCfg.TimeoutMillis, params)
 	if err != nil {
 		params.Logger.Error("failed to connect to rate limit service ", zap.Error(err))
 		return nil, err

--- a/processors/ratelimiter/factory.go
+++ b/processors/ratelimiter/factory.go
@@ -22,7 +22,7 @@ const (
 	defaultDomain                   = "collector"
 	defaultDomainSoftLimitThreshold = uint32(100000) // Soft limit kicks in when limit remaining under 100k
 	defaultHeaderName               = "x-tenant-id"
-	defaultTimeoutMillis            = uint16(1000) // 1 second
+	defaultTimeoutMillis            = uint32(1000) // 1 second
 )
 
 // NewFactory creates a factory for the ratelimit processor.

--- a/processors/ratelimiter/factory_test.go
+++ b/processors/ratelimiter/factory_test.go
@@ -1,0 +1,16 @@
+package ratelimiter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateDefaultConfig(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	assert.Equal(t, defaultHeaderName, cfg.TenantIDHeaderName)
+	assert.Equal(t, defaultServiceHost, cfg.RateLimitServiceHost)
+	assert.Equal(t, defaultServicePort, cfg.RateLimitServicePort)
+	assert.Equal(t, defaultDomainSoftLimitThreshold, cfg.DomainSoftRateLimitThreshold)
+	assert.Equal(t, defaultDomain, cfg.Domain)
+}

--- a/processors/ratelimiter/factory_test.go
+++ b/processors/ratelimiter/factory_test.go
@@ -9,9 +9,9 @@ import (
 func TestCreateDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	assert.Equal(t, defaultHeaderName, cfg.TenantIDHeaderName)
-	assert.Equal(t, defaultServiceHost, cfg.RateLimitServiceHost)
-	assert.Equal(t, defaultServicePort, cfg.RateLimitServicePort)
+	assert.Equal(t, defaultServiceHost, cfg.ServiceHost)
+	assert.Equal(t, defaultServicePort, cfg.ServicePort)
 	assert.Equal(t, defaultDomainSoftLimitThreshold, cfg.DomainSoftRateLimitThreshold)
 	assert.Equal(t, defaultDomain, cfg.Domain)
-	assert.Equal(t, defaultTimeoutMillis, cfg.RateLimitServiceTimeoutMillis)
+	assert.Equal(t, defaultTimeoutMillis, cfg.TimeoutMillis)
 }

--- a/processors/ratelimiter/factory_test.go
+++ b/processors/ratelimiter/factory_test.go
@@ -13,4 +13,5 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.Equal(t, defaultServicePort, cfg.RateLimitServicePort)
 	assert.Equal(t, defaultDomainSoftLimitThreshold, cfg.DomainSoftRateLimitThreshold)
 	assert.Equal(t, defaultDomain, cfg.Domain)
+	assert.Equal(t, defaultTimeoutMillis, cfg.RateLimitServiceTimeoutMillis)
 }

--- a/processors/ratelimiter/metrics.go
+++ b/processors/ratelimiter/metrics.go
@@ -1,0 +1,39 @@
+package ratelimiter
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var (
+	tagTenantID               = tag.MustNewKey("tenant-id")
+	droppedSpanCountSoftLimit = stats.Int64("tenant_id_dropped_span_count_soft_limit",
+		"Number of spans dropped because of rate limiting per tenant due to soft limit", stats.UnitDimensionless)
+	droppedSpanCount = stats.Int64("tenant_id_dropped_span_count", "Number of spans dropped per tenant due to global rate limiting", stats.UnitDimensionless)
+)
+
+func MetricViews() []*view.View {
+	tags := []tag.Key{tagTenantID}
+
+	viewDroppedSpanCountSoftLimit := &view.View{
+		Name:        droppedSpanCountSoftLimit.Name(),
+		Description: droppedSpanCountSoftLimit.Description(),
+		Measure:     droppedSpanCountSoftLimit,
+		Aggregation: view.Sum(),
+		TagKeys:     tags,
+	}
+
+	viewDroppedSpanCount := &view.View{
+		Name:        droppedSpanCount.Name(),
+		Description: droppedSpanCount.Description(),
+		Measure:     droppedSpanCount,
+		Aggregation: view.Sum(),
+		TagKeys:     tags,
+	}
+
+	return []*view.View{
+		viewDroppedSpanCountSoftLimit,
+		viewDroppedSpanCount,
+	}
+}

--- a/processors/ratelimiter/ratelimiterprocessor.go
+++ b/processors/ratelimiter/ratelimiterprocessor.go
@@ -8,6 +8,7 @@ import (
 	pb_struct "github.com/envoyproxy/go-control-plane/envoy/extensions/common/ratelimit/v3"
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
 	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -24,6 +25,30 @@ var (
 	droppedSpanCount          = stats.Int64("tenant_id_dropped_span_count", "Number of spans dropped per tenant due to global rate limiting", stats.UnitDimensionless)
 )
 
+func MetricViews() []*view.View {
+	tags := []tag.Key{tagTenantID}
+
+	viewDroppedSpanCountSoftLimit := &view.View{
+		Name:        droppedSpanCountSoftLimit.Name(),
+		Description: droppedSpanCountSoftLimit.Description(),
+		Measure:     droppedSpanCountSoftLimit,
+		Aggregation: view.Sum(),
+		TagKeys:     tags,
+	}
+
+	viewDroppedSpanCount := &view.View{
+		Name:        droppedSpanCount.Name(),
+		Description: droppedSpanCount.Description(),
+		Measure:     droppedSpanCount,
+		Aggregation: view.Sum(),
+		TagKeys:     tags,
+	}
+
+	return []*view.View{
+		viewDroppedSpanCountSoftLimit,
+		viewDroppedSpanCount,
+	}
+}
 func (p *processor) Start(_ context.Context, _ component.Host) error {
 	return nil
 }

--- a/processors/ratelimiter/ratelimiterprocessor.go
+++ b/processors/ratelimiter/ratelimiterprocessor.go
@@ -7,10 +7,31 @@ import (
 
 	pb_struct "github.com/envoyproxy/go-control-plane/envoy/extensions/common/ratelimit/v3"
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	"go.opencensus.io/stats"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/metadata"
 )
+
+var _ component.TracesProcessor = (*processor)(nil)
+
+var (
+	droppedSpanCount = stats.Int64("dropped_span_count", "Number of spans dropped because of rate limiting", stats.UnitDimensionless)
+)
+
+func (p *processor) Start(_ context.Context, _ component.Host) error {
+	return nil
+}
+
+func (p *processor) Shutdown(_ context.Context) error {
+	return nil
+}
+
+func (p *processor) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: true}
+}
 
 type processor struct {
 	rateLimitServiceClient   pb.RateLimitServiceClient
@@ -18,6 +39,7 @@ type processor struct {
 	domainSoftLimitThreshold uint32
 	logger                   *zap.Logger
 	tenantIDHeaderName       string
+	nextConsumer             consumer.Traces
 }
 
 const (
@@ -26,12 +48,13 @@ const (
 )
 
 // ProcessTraces implements processorhelper.ProcessTracesFunc
-func (p *processor) ProcessTraces(ctx context.Context, traces ptrace.Traces) (ptrace.Traces, error) {
+func (p *processor) ConsumeTraces(ctx context.Context, traces ptrace.Traces) error {
 	tenantId, err := p.getTenantId(ctx)
 	if err != nil {
-		return traces, nil
+		// If tenantId is missing, rate limiting not applicable.
+		return p.nextConsumer.ConsumeTraces(ctx, traces)
 	}
-	// two descriptors, one for tenant and other one for domain
+	// two descriptors, one for tenant and other one for domain(cluster)
 	desc := make([]*pb_struct.RateLimitDescriptor, 2)
 	desc[0] = &pb_struct.RateLimitDescriptor{
 		Entries: []*pb_struct.RateLimitDescriptor_Entry{
@@ -60,28 +83,30 @@ func (p *processor) ProcessTraces(ctx context.Context, traces ptrace.Traces) (pt
 	if err != nil {
 		// Rate limit service call fails, spans will be forwarded as it is.
 		p.logger.Error("rate limit service call failed", zap.Error(err))
-		return traces, nil
+		return p.nextConsumer.ConsumeTraces(ctx, traces)
 	}
 	descriptorStatuses := response.Statuses
-	if descriptorStatuses != nil {
+	if len(descriptorStatuses) != 0 {
 		if descriptorStatuses[1].GetCode() == pb.RateLimitResponse_OVER_LIMIT {
 			// If global rate limit exceeded drop all events
-			return traces, fmt.Errorf("dropping spans for tenant %s due to global rate limit exceeded, of spancount: %d", tenantId, traces.SpanCount())
-		}
-		if descriptorStatuses[1].LimitRemaining < p.domainSoftLimitThreshold && descriptorStatuses[0].GetCode() == pb.RateLimitResponse_OVER_LIMIT {
+			p.logger.Warn(fmt.Sprintf("dropping spans for tenant %s due to global rate limit exceeded, of spancount: %d", tenantId, traces.SpanCount()))
+			stats.Record(ctx, droppedSpanCount.M(int64(spanCount)))
+			return nil
+		} else if descriptorStatuses[1].LimitRemaining < p.domainSoftLimitThreshold && descriptorStatuses[0].GetCode() == pb.RateLimitResponse_OVER_LIMIT {
 			// If soft limit reached then drop only spans from tenants where tenant specific limit exceeded.
-			return traces, fmt.Errorf("dropping spans for tenant %s due to soft limit reached, of spancount: %d", tenantId, traces.SpanCount())
+			p.logger.Warn(fmt.Sprintf("dropping spans for tenant %s due to soft limit reached, of spancount: %d", tenantId, traces.SpanCount()))
+			stats.Record(ctx, droppedSpanCount.M(int64(spanCount)))
+			return nil
 		}
 		// Ignore dropping of spans when soft limit hasn't reached even though tenant rate limit reached.
 	}
-
-	return traces, nil
+	return p.nextConsumer.ConsumeTraces(ctx, traces)
 }
 
 func (p *processor) getTenantId(ctx context.Context) (string, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return "", fmt.Errorf("could not extract headers from context. ")
+		return "", fmt.Errorf("could not extract headers from context")
 	}
 
 	tenantIDHeaders := md.Get(p.tenantIDHeaderName)

--- a/processors/ratelimiter/ratelimiterprocessor.go
+++ b/processors/ratelimiter/ratelimiterprocessor.go
@@ -1,0 +1,95 @@
+package ratelimiter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	pb_struct "github.com/envoyproxy/go-control-plane/envoy/extensions/common/ratelimit/v3"
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/metadata"
+)
+
+type processor struct {
+	rateLimitServiceClient   pb.RateLimitServiceClient
+	domain                   string
+	domainSoftLimitThreshold uint32
+	logger                   *zap.Logger
+	tenantIDHeaderName       string
+}
+
+const (
+	TenantID       = "tenant_id"
+	GlobalTenantID = "global_tenant_id"
+)
+
+// ProcessTraces implements processorhelper.ProcessTracesFunc
+func (p *processor) ProcessTraces(ctx context.Context, traces ptrace.Traces) (ptrace.Traces, error) {
+	tenantId, err := p.getTenantId(ctx)
+	if err != nil {
+		return traces, nil
+	}
+	// two descriptors, one for tenant and other one for domain
+	desc := make([]*pb_struct.RateLimitDescriptor, 2)
+	desc[0] = &pb_struct.RateLimitDescriptor{
+		Entries: []*pb_struct.RateLimitDescriptor_Entry{
+			{
+				Key:   TenantID,
+				Value: tenantId,
+			},
+		},
+	}
+	desc[1] = &pb_struct.RateLimitDescriptor{
+		Entries: []*pb_struct.RateLimitDescriptor_Entry{
+			{
+				Key:   TenantID,
+				Value: GlobalTenantID,
+			},
+		},
+	}
+	spanCount := uint32(traces.SpanCount())
+	response, err := p.rateLimitServiceClient.ShouldRateLimit(
+		ctx,
+		&pb.RateLimitRequest{
+			Domain:      p.domain,
+			Descriptors: desc,
+			HitsAddend:  spanCount,
+		})
+	if err != nil {
+		// Rate limit service call fails, spans will be forwarded as it is.
+		p.logger.Error("rate limit service call failed", zap.Error(err))
+		return traces, nil
+	}
+	descriptorStatuses := response.Statuses
+	if descriptorStatuses != nil {
+		if descriptorStatuses[1].GetCode() == pb.RateLimitResponse_OVER_LIMIT {
+			// If global rate limit exceeded drop all events
+			return traces, fmt.Errorf("dropping spans for tenant %s due to global rate limit exceeded, of spancount: %d", tenantId, traces.SpanCount())
+		}
+		if descriptorStatuses[1].LimitRemaining < p.domainSoftLimitThreshold && descriptorStatuses[0].GetCode() == pb.RateLimitResponse_OVER_LIMIT {
+			// If soft limit reached then drop only spans from tenants where tenant specific limit exceeded.
+			return traces, fmt.Errorf("dropping spans for tenant %s due to soft limit reached, of spancount: %d", tenantId, traces.SpanCount())
+		}
+		// Ignore dropping of spans when soft limit hasn't reached even though tenant rate limit reached.
+	}
+
+	return traces, nil
+}
+
+func (p *processor) getTenantId(ctx context.Context) (string, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", fmt.Errorf("could not extract headers from context. ")
+	}
+
+	tenantIDHeaders := md.Get(p.tenantIDHeaderName)
+	if len(tenantIDHeaders) == 0 {
+		return "", fmt.Errorf("missing header: %s", p.tenantIDHeaderName)
+	} else if len(tenantIDHeaders) > 1 {
+		return "", fmt.Errorf("multiple tenant ID headers were provided, %s: %s", p.tenantIDHeaderName, strings.Join(tenantIDHeaders, ", "))
+	}
+
+	return tenantIDHeaders[0], nil
+}

--- a/processors/ratelimiter/ratelimiterprocessor.go
+++ b/processors/ratelimiter/ratelimiterprocessor.go
@@ -8,7 +8,6 @@ import (
 	pb_struct "github.com/envoyproxy/go-control-plane/envoy/extensions/common/ratelimit/v3"
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
 	"go.opencensus.io/stats"
-	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -20,36 +19,6 @@ import (
 
 var _ component.TracesProcessor = (*processor)(nil)
 
-var (
-	tagTenantID               = tag.MustNewKey("tenant-id")
-	droppedSpanCountSoftLimit = stats.Int64("tenant_id_dropped_span_count_soft_limit", "Number of spans dropped because of rate limiting per tenant due to soft limit", stats.UnitDimensionless)
-	droppedSpanCount          = stats.Int64("tenant_id_dropped_span_count", "Number of spans dropped per tenant due to global rate limiting", stats.UnitDimensionless)
-)
-
-func MetricViews() []*view.View {
-	tags := []tag.Key{tagTenantID}
-
-	viewDroppedSpanCountSoftLimit := &view.View{
-		Name:        droppedSpanCountSoftLimit.Name(),
-		Description: droppedSpanCountSoftLimit.Description(),
-		Measure:     droppedSpanCountSoftLimit,
-		Aggregation: view.Sum(),
-		TagKeys:     tags,
-	}
-
-	viewDroppedSpanCount := &view.View{
-		Name:        droppedSpanCount.Name(),
-		Description: droppedSpanCount.Description(),
-		Measure:     droppedSpanCount,
-		Aggregation: view.Sum(),
-		TagKeys:     tags,
-	}
-
-	return []*view.View{
-		viewDroppedSpanCountSoftLimit,
-		viewDroppedSpanCount,
-	}
-}
 func (p *processor) Start(_ context.Context, _ component.Host) error {
 	return nil
 }

--- a/processors/ratelimiter/ratelimiterprocessor_test.go
+++ b/processors/ratelimiter/ratelimiterprocessor_test.go
@@ -1,0 +1,230 @@
+package ratelimiter
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	"github.com/hypertrace/collector/processors/testutil"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+const testTenantID = "jdoe"
+
+type MockRateLimitServiceClient struct {
+	mock.Mock
+}
+
+type MockProcessorConsumer struct {
+	mock.Mock
+}
+
+var _ component.TracesProcessor = (*MockProcessorConsumer)(nil)
+
+func (p *MockProcessorConsumer) Start(_ context.Context, _ component.Host) error {
+	return nil
+}
+
+func (p *MockProcessorConsumer) Shutdown(_ context.Context) error {
+	return nil
+}
+
+func (p *MockProcessorConsumer) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: true}
+}
+
+func (m *MockRateLimitServiceClient) ShouldRateLimit(ctx context.Context, in *pb.RateLimitRequest, opts ...grpc.CallOption) (*pb.RateLimitResponse, error) {
+	args := m.Called(ctx, in)
+	if args.Get(1) == nil {
+		return args.Get(0).(*pb.RateLimitResponse), nil
+	}
+	return nil, args.Get(1).(error)
+}
+
+func (f *MockProcessorConsumer) ConsumeTraces(ctx context.Context, ld ptrace.Traces) error {
+	args := f.Called(ctx, ld)
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(error)
+}
+
+func TestRateLimitingWhenEmptyTenantHeader(t *testing.T) {
+	mockRateLimitServiceClientObj := new(MockRateLimitServiceClient)
+	mockProcessorConsumerObj := new(MockProcessorConsumer)
+	p := &processor{
+		logger:                   zap.NewNop(),
+		tenantIDHeaderName:       defaultHeaderName,
+		domain:                   defaultDomain,
+		domainSoftLimitThreshold: defaultDomainSoftLimitThreshold,
+		rateLimitServiceClient:   mockRateLimitServiceClientObj,
+		nextConsumer:             mockProcessorConsumerObj,
+	}
+	mockRateLimitServiceClientObj.On("ShouldRateLimit", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("rate limit called failed"))
+	mockProcessorConsumerObj.On("ConsumeTraces", mock.Anything, mock.Anything).Return(nil)
+	tokenString := base64.StdEncoding.EncodeToString([]byte("testuser:passw123"))
+	span := testutil.NewTestSpan("http.request.header.authorization", "Basic: "+tokenString)
+	traces := testutil.NewTestTraces(span)
+	md := metadata.New(map[string]string{})
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		md,
+	)
+	err := p.ConsumeTraces(ctx, traces)
+	require.NoError(t, err)
+	mockRateLimitServiceClientObj.AssertNumberOfCalls(t, "ShouldRateLimit", 0)
+	mockProcessorConsumerObj.AssertNumberOfCalls(t, "ConsumeTraces", 1)
+}
+
+func TestWhenRateLimitServiceCallFailed(t *testing.T) {
+	mockRateLimitServiceClientObj := new(MockRateLimitServiceClient)
+	mockProcessorConsumerObj := new(MockProcessorConsumer)
+	p := &processor{
+		logger:                   zap.NewNop(),
+		tenantIDHeaderName:       defaultHeaderName,
+		domain:                   defaultDomain,
+		domainSoftLimitThreshold: defaultDomainSoftLimitThreshold,
+		rateLimitServiceClient:   mockRateLimitServiceClientObj,
+		nextConsumer:             mockProcessorConsumerObj,
+	}
+	mockRateLimitServiceClientObj.On("ShouldRateLimit", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("rate limit called failed"))
+	mockProcessorConsumerObj.On("ConsumeTraces", mock.Anything, mock.Anything).Return(nil)
+	tokenString := base64.StdEncoding.EncodeToString([]byte("testuser:passw123"))
+	span := testutil.NewTestSpan("http.request.header.authorization", "Basic: "+tokenString)
+	traces := testutil.NewTestTraces(span)
+	md := metadata.New(map[string]string{p.tenantIDHeaderName: testTenantID})
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		md,
+	)
+	err := p.ConsumeTraces(ctx, traces)
+	require.NoError(t, err)
+	mockRateLimitServiceClientObj.AssertNumberOfCalls(t, "ShouldRateLimit", 1)
+	mockProcessorConsumerObj.AssertNumberOfCalls(t, "ConsumeTraces", 1)
+}
+
+func TestRateLimitingWhenSoftLimitNotReachedButTenantLimitReached(t *testing.T) {
+	mockRateLimitServiceClientObj := new(MockRateLimitServiceClient)
+	mockProcessorConsumerObj := new(MockProcessorConsumer)
+	p := &processor{
+		logger:                   zap.NewNop(),
+		tenantIDHeaderName:       defaultHeaderName,
+		domain:                   defaultDomain,
+		domainSoftLimitThreshold: 2,
+		rateLimitServiceClient:   mockRateLimitServiceClientObj,
+		nextConsumer:             mockProcessorConsumerObj,
+	}
+	rateLimitResponse := &pb.RateLimitResponse{
+		OverallCode: pb.RateLimitResponse_OK,
+		Statuses: []*pb.RateLimitResponse_DescriptorStatus{
+			{
+				Code: pb.RateLimitResponse_OVER_LIMIT,
+			},
+			{
+				Code:           pb.RateLimitResponse_OK,
+				LimitRemaining: 5,
+			},
+		},
+	}
+	mockRateLimitServiceClientObj.On("ShouldRateLimit", mock.Anything, mock.Anything).Return(rateLimitResponse, nil)
+	mockProcessorConsumerObj.On("ConsumeTraces", mock.Anything, mock.Anything).Return(nil)
+	tokenString := base64.StdEncoding.EncodeToString([]byte("testuser:passw123"))
+	span := testutil.NewTestSpan("http.request.header.authorization", "Basic: "+tokenString)
+	traces := testutil.NewTestTraces(span)
+	md := metadata.New(map[string]string{p.tenantIDHeaderName: testTenantID})
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		md,
+	)
+	err := p.ConsumeTraces(ctx, traces)
+	require.NoError(t, err)
+	mockRateLimitServiceClientObj.AssertNumberOfCalls(t, "ShouldRateLimit", 1)
+	mockProcessorConsumerObj.AssertNumberOfCalls(t, "ConsumeTraces", 1)
+}
+
+func TestRateLimitingWhenSoftLimitReachedAndTenantLimitReached(t *testing.T) {
+	mockRateLimitServiceClientObj := new(MockRateLimitServiceClient)
+	mockProcessorConsumerObj := new(MockProcessorConsumer)
+	p := &processor{
+		logger:                   zap.NewNop(),
+		tenantIDHeaderName:       defaultHeaderName,
+		domain:                   defaultDomain,
+		domainSoftLimitThreshold: 2,
+		rateLimitServiceClient:   mockRateLimitServiceClientObj,
+		nextConsumer:             mockProcessorConsumerObj,
+	}
+	rateLimitResponse := &pb.RateLimitResponse{
+		OverallCode: pb.RateLimitResponse_OK,
+		Statuses: []*pb.RateLimitResponse_DescriptorStatus{
+			{
+				Code: pb.RateLimitResponse_OVER_LIMIT,
+			},
+			{
+				Code:           pb.RateLimitResponse_OK,
+				LimitRemaining: 1,
+			},
+		},
+	}
+	mockRateLimitServiceClientObj.On("ShouldRateLimit", mock.Anything, mock.Anything).Return(rateLimitResponse, nil)
+	mockProcessorConsumerObj.On("ConsumeTraces", mock.Anything, mock.Anything).Return(nil)
+	tokenString := base64.StdEncoding.EncodeToString([]byte("testuser:passw123"))
+	span := testutil.NewTestSpan("http.request.header.authorization", "Basic: "+tokenString)
+	traces := testutil.NewTestTraces(span)
+	md := metadata.New(map[string]string{p.tenantIDHeaderName: testTenantID})
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		md,
+	)
+	err := p.ConsumeTraces(ctx, traces)
+	require.NoError(t, err)
+	mockRateLimitServiceClientObj.AssertNumberOfCalls(t, "ShouldRateLimit", 1)
+	mockProcessorConsumerObj.AssertNumberOfCalls(t, "ConsumeTraces", 0)
+}
+
+func TestRateLimitingWhenHardLimitReached(t *testing.T) {
+	mockRateLimitServiceClientObj := new(MockRateLimitServiceClient)
+	mockProcessorConsumerObj := new(MockProcessorConsumer)
+	p := &processor{
+		logger:                   zap.NewNop(),
+		tenantIDHeaderName:       defaultHeaderName,
+		domain:                   defaultDomain,
+		domainSoftLimitThreshold: 2,
+		rateLimitServiceClient:   mockRateLimitServiceClientObj,
+		nextConsumer:             mockProcessorConsumerObj,
+	}
+	rateLimitResponse := &pb.RateLimitResponse{
+		OverallCode: pb.RateLimitResponse_OK,
+		Statuses: []*pb.RateLimitResponse_DescriptorStatus{
+			{
+				Code: pb.RateLimitResponse_OK,
+			},
+			{
+				Code: pb.RateLimitResponse_OVER_LIMIT,
+			},
+		},
+	}
+	mockRateLimitServiceClientObj.On("ShouldRateLimit", mock.Anything, mock.Anything).Return(rateLimitResponse, nil)
+	mockProcessorConsumerObj.On("ConsumeTraces", mock.Anything, mock.Anything).Return(nil)
+	tokenString := base64.StdEncoding.EncodeToString([]byte("testuser:passw123"))
+	span := testutil.NewTestSpan("http.request.header.authorization", "Basic: "+tokenString)
+	traces := testutil.NewTestTraces(span)
+	md := metadata.New(map[string]string{p.tenantIDHeaderName: testTenantID})
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		md,
+	)
+	err := p.ConsumeTraces(ctx, traces)
+	require.NoError(t, err)
+	mockRateLimitServiceClientObj.AssertNumberOfCalls(t, "ShouldRateLimit", 1)
+	mockProcessorConsumerObj.AssertNumberOfCalls(t, "ConsumeTraces", 0)
+}

--- a/processors/ratelimiter/ratelimiterprocessor_test.go
+++ b/processors/ratelimiter/ratelimiterprocessor_test.go
@@ -31,15 +31,15 @@ type MockProcessorConsumer struct {
 
 var _ component.TracesProcessor = (*MockProcessorConsumer)(nil)
 
-func (p *MockProcessorConsumer) Start(_ context.Context, _ component.Host) error {
+func (m *MockProcessorConsumer) Start(_ context.Context, _ component.Host) error {
 	return nil
 }
 
-func (p *MockProcessorConsumer) Shutdown(_ context.Context) error {
+func (m *MockProcessorConsumer) Shutdown(_ context.Context) error {
 	return nil
 }
 
-func (p *MockProcessorConsumer) Capabilities() consumer.Capabilities {
+func (m *MockProcessorConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
 }
 
@@ -51,8 +51,8 @@ func (m *MockRateLimitServiceClient) ShouldRateLimit(ctx context.Context, in *pb
 	return nil, args.Get(1).(error)
 }
 
-func (f *MockProcessorConsumer) ConsumeTraces(ctx context.Context, ld ptrace.Traces) error {
-	args := f.Called(ctx, ld)
+func (m *MockProcessorConsumer) ConsumeTraces(ctx context.Context, ld ptrace.Traces) error {
+	args := m.Called(ctx, ld)
 	if args.Get(0) == nil {
 		return nil
 	}

--- a/processors/ratelimiter/ratelimiterprocessor_test.go
+++ b/processors/ratelimiter/ratelimiterprocessor_test.go
@@ -63,12 +63,14 @@ func TestRateLimitingWhenEmptyTenantHeader(t *testing.T) {
 	mockRateLimitServiceClientObj := new(MockRateLimitServiceClient)
 	mockProcessorConsumerObj := new(MockProcessorConsumer)
 	p := &processor{
-		logger:                   zap.NewNop(),
-		tenantIDHeaderName:       defaultHeaderName,
-		domain:                   defaultDomain,
-		domainSoftLimitThreshold: defaultDomainSoftLimitThreshold,
-		rateLimitServiceClient:   mockRateLimitServiceClientObj,
-		nextConsumer:             mockProcessorConsumerObj,
+		logger:                     zap.NewNop(),
+		tenantIDHeaderName:         defaultHeaderName,
+		domain:                     defaultDomain,
+		domainSoftLimitThreshold:   defaultDomainSoftLimitThreshold,
+		rateLimitServiceClient:     mockRateLimitServiceClientObj,
+		rateLimitServiceClientConn: &grpc.ClientConn{},
+		cancelFunc:                 t.SkipNow,
+		nextConsumer:               mockProcessorConsumerObj,
 	}
 	mockRateLimitServiceClientObj.On("ShouldRateLimit", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("rate limit called failed"))
 	mockProcessorConsumerObj.On("ConsumeTraces", mock.Anything, mock.Anything).Return(nil)
@@ -90,12 +92,14 @@ func TestWhenRateLimitServiceCallFailed(t *testing.T) {
 	mockRateLimitServiceClientObj := new(MockRateLimitServiceClient)
 	mockProcessorConsumerObj := new(MockProcessorConsumer)
 	p := &processor{
-		logger:                   zap.NewNop(),
-		tenantIDHeaderName:       defaultHeaderName,
-		domain:                   defaultDomain,
-		domainSoftLimitThreshold: defaultDomainSoftLimitThreshold,
-		rateLimitServiceClient:   mockRateLimitServiceClientObj,
-		nextConsumer:             mockProcessorConsumerObj,
+		logger:                     zap.NewNop(),
+		tenantIDHeaderName:         defaultHeaderName,
+		domain:                     defaultDomain,
+		domainSoftLimitThreshold:   defaultDomainSoftLimitThreshold,
+		rateLimitServiceClient:     mockRateLimitServiceClientObj,
+		rateLimitServiceClientConn: &grpc.ClientConn{},
+		cancelFunc:                 t.SkipNow,
+		nextConsumer:               mockProcessorConsumerObj,
 	}
 	mockRateLimitServiceClientObj.On("ShouldRateLimit", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("rate limit called failed"))
 	mockProcessorConsumerObj.On("ConsumeTraces", mock.Anything, mock.Anything).Return(nil)
@@ -117,12 +121,14 @@ func TestRateLimitingWhenSoftLimitNotReachedButTenantLimitReached(t *testing.T) 
 	mockRateLimitServiceClientObj := new(MockRateLimitServiceClient)
 	mockProcessorConsumerObj := new(MockProcessorConsumer)
 	p := &processor{
-		logger:                   zap.NewNop(),
-		tenantIDHeaderName:       defaultHeaderName,
-		domain:                   defaultDomain,
-		domainSoftLimitThreshold: 2,
-		rateLimitServiceClient:   mockRateLimitServiceClientObj,
-		nextConsumer:             mockProcessorConsumerObj,
+		logger:                     zap.NewNop(),
+		tenantIDHeaderName:         defaultHeaderName,
+		domain:                     defaultDomain,
+		domainSoftLimitThreshold:   2,
+		rateLimitServiceClient:     mockRateLimitServiceClientObj,
+		rateLimitServiceClientConn: &grpc.ClientConn{},
+		cancelFunc:                 t.SkipNow,
+		nextConsumer:               mockProcessorConsumerObj,
 	}
 	rateLimitResponse := &pb.RateLimitResponse{
 		OverallCode: pb.RateLimitResponse_OK,
@@ -156,12 +162,14 @@ func TestRateLimitingWhenSoftLimitReachedAndTenantLimitReached(t *testing.T) {
 	mockRateLimitServiceClientObj := new(MockRateLimitServiceClient)
 	mockProcessorConsumerObj := new(MockProcessorConsumer)
 	p := &processor{
-		logger:                   zap.NewNop(),
-		tenantIDHeaderName:       defaultHeaderName,
-		domain:                   defaultDomain,
-		domainSoftLimitThreshold: 2,
-		rateLimitServiceClient:   mockRateLimitServiceClientObj,
-		nextConsumer:             mockProcessorConsumerObj,
+		logger:                     zap.NewNop(),
+		tenantIDHeaderName:         defaultHeaderName,
+		domain:                     defaultDomain,
+		domainSoftLimitThreshold:   2,
+		rateLimitServiceClient:     mockRateLimitServiceClientObj,
+		rateLimitServiceClientConn: &grpc.ClientConn{},
+		cancelFunc:                 t.SkipNow,
+		nextConsumer:               mockProcessorConsumerObj,
 	}
 	rateLimitResponse := &pb.RateLimitResponse{
 		OverallCode: pb.RateLimitResponse_OK,
@@ -195,12 +203,14 @@ func TestRateLimitingWhenHardLimitReached(t *testing.T) {
 	mockRateLimitServiceClientObj := new(MockRateLimitServiceClient)
 	mockProcessorConsumerObj := new(MockProcessorConsumer)
 	p := &processor{
-		logger:                   zap.NewNop(),
-		tenantIDHeaderName:       defaultHeaderName,
-		domain:                   defaultDomain,
-		domainSoftLimitThreshold: 2,
-		rateLimitServiceClient:   mockRateLimitServiceClientObj,
-		nextConsumer:             mockProcessorConsumerObj,
+		logger:                     zap.NewNop(),
+		tenantIDHeaderName:         defaultHeaderName,
+		domain:                     defaultDomain,
+		domainSoftLimitThreshold:   2,
+		rateLimitServiceClient:     mockRateLimitServiceClientObj,
+		rateLimitServiceClientConn: &grpc.ClientConn{},
+		cancelFunc:                 t.SkipNow,
+		nextConsumer:               mockProcessorConsumerObj,
 	}
 	rateLimitResponse := &pb.RateLimitResponse{
 		OverallCode: pb.RateLimitResponse_OK,

--- a/processors/ratelimiter/testdata/config.yml
+++ b/processors/ratelimiter/testdata/config.yml
@@ -8,6 +8,7 @@ processors:
     service_port: 8081
     domain: app
     domain_soft_limit_threshold: 10
+    timeout_millis: 10
 exporters:
   nop:
 

--- a/processors/ratelimiter/testdata/config.yml
+++ b/processors/ratelimiter/testdata/config.yml
@@ -3,7 +3,7 @@ receivers:
 
 processors:
   hypertrace_ratelimiter:
-    header_name: header-tenant  
+    tenant_id_header_name: header-tenant
     service_host: localhost
     service_port: 8081
     domain: app

--- a/processors/ratelimiter/testdata/config.yml
+++ b/processors/ratelimiter/testdata/config.yml
@@ -1,0 +1,18 @@
+receivers:
+  nop:
+
+processors:
+  hypertrace_ratelimiter:
+    header_name: header-tenant  
+    service_host: localhost
+    service_port: 8081
+    domain: app
+    domain_soft_limit_threshold: 10
+exporters:
+  nop:
+
+service:
+  pipelines:
+    traces:
+      receivers: [nop]
+      exporters: [nop]

--- a/processors/testutil/testutils.go
+++ b/processors/testutil/testutils.go
@@ -1,0 +1,97 @@
+package testutil
+
+import (
+	"github.com/google/uuid"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func NewTestTraces(spans ...ptrace.Span) ptrace.Traces {
+	t := ptrace.NewTraces()
+	rs := ptrace.NewResourceSpans()
+	scsp := ptrace.NewScopeSpans()
+
+	for i := 0; i < len(spans); i++ {
+		scsp.Spans().AppendEmpty()
+	}
+	for i, s := range spans {
+		s.CopyTo(scsp.Spans().At(i))
+	}
+
+	rs.ScopeSpans().AppendEmpty()
+	scsp.CopyTo(rs.ScopeSpans().At(0))
+
+	t.ResourceSpans().AppendEmpty()
+	rs.CopyTo(t.ResourceSpans().At(0))
+	return t
+}
+
+// NewTestSpan creates a new span with a set of attributes. This reduces the burden
+// of wrapping values continuously inside tests.
+func NewTestSpan(attrKVs ...interface{}) ptrace.Span {
+	return NewTestSpanWithTraceId(CreateNewTraceId(), attrKVs...)
+}
+
+func NewTestSpanWithNameAndSpanKind(spanKind ptrace.SpanKind, name string, attrKVs ...interface{}) ptrace.Span {
+	return NewTestSpanWithTraceIdAndNameAndSpanKind(CreateNewTraceId(), CreateNewSpanId(), name, spanKind, attrKVs...)
+}
+
+func NewTestSpanWithTraceId(traceId pcommon.TraceID, attrKVs ...interface{}) ptrace.Span {
+	return NewTestSpanWithTraceIdAndNameAndSpanKind(traceId, CreateNewSpanId(), "test", ptrace.SpanKindServer, attrKVs...)
+}
+
+func NewTestSpanWithTraceIdAndSpanId(traceId pcommon.TraceID, spanId pcommon.SpanID, attrKVs ...interface{}) ptrace.Span {
+	return NewTestSpanWithTraceIdAndNameAndSpanKind(traceId, spanId, "test", ptrace.SpanKindServer, attrKVs...)
+}
+
+func CreateNewTraceId() pcommon.TraceID {
+	traceUuidBytesSlice, _ := uuid.New().MarshalBinary()
+	var traceUuidBytes [16]byte
+	copy(traceUuidBytes[:], traceUuidBytesSlice)
+	return traceUuidBytes
+}
+
+func CreateNewSpanId() pcommon.SpanID {
+	uuidBytesSlice, _ := uuid.New().MarshalBinary()
+	var spanUuidBytes [8]byte
+	copy(spanUuidBytes[:], uuidBytesSlice)
+	return spanUuidBytes
+}
+
+func NewTestSpanWithTraceIdAndNameAndSpanKind(traceId pcommon.TraceID, spanId pcommon.SpanID, name string, spanKind ptrace.SpanKind, attrKVs ...interface{}) ptrace.Span {
+	s := ptrace.NewSpan()
+	s.SetTraceID(traceId)
+	s.SetSpanID(spanId)
+	s.SetName(name)
+	s.SetKind(spanKind)
+
+	for i := 0; i < len(attrKVs); i = i + 2 {
+		var val pcommon.Value
+		switch attrKVs[i+1].(type) {
+		case string:
+			val = pcommon.NewValueString(attrKVs[i+1].(string))
+			s.Attributes().PutString(attrKVs[i].(string), val.Str())
+		case int, int8, int16, int32, int64:
+			val = pcommon.NewValueInt(int64(attrKVs[i+1].(int)))
+			s.Attributes().PutInt(attrKVs[i].(string), val.Int())
+		case bool:
+			val = pcommon.NewValueBool(attrKVs[i+1].(bool))
+			s.Attributes().PutBool(attrKVs[i].(string), val.Bool())
+		}
+	}
+
+	return s
+}
+
+func NewAttributeMap() pcommon.Map {
+	attributeMap := pcommon.NewMap()
+	return attributeMap
+}
+
+func NewAttributeMapFromStringMap(m map[string]string) pcommon.Map {
+	attributeMap := pcommon.NewMap()
+	for k, v := range m {
+		attributeMap.PutString(k, v)
+	}
+	return attributeMap
+}


### PR DESCRIPTION
## Description
Add rate limiter processor which helps in rate limiting spans which uses envoy based rate limit service. 


- **Rate Limit Support**: Add rate limit processor which rate limits the requests based on span count and it needs rate limit service deployed using https://github.com/envoyproxy/ratelimit. 
- There are tenant level limits and cluster level limits. For cluster level there is soft limit and hard limit. All spans will be dropped if cluster hard limit reached. If soft limit reached, requests will be dropped from tenants where tenant level limit reached.


### Testing
ratelimitprocessor_test has tests which tests following scenarios.
1. When rate limit service not available
2. When tenant header is missing.
3. When cluster level soft limit reached but hard limit not reached.
4. When cluster level hard limit reached. 



<!--
Include __important__ links regarding the implementation of this PR.
Rate limit processor requires https://github.com/envoyproxy/ratelimit
-->
