### PR TITLE
Simplified rate limiting and removed soft limit config

### DIFF
--- a/processors/ratelimiter/config.go
+++ b/processors/ratelimiter/config.go
@@ -18,8 +18,6 @@ type Config struct {
 	ServicePort uint16 `mapstructure:"service_port"`
 	//Domain  rate limit configuration domain to query. Default collector
 	Domain string `mapstructure:"domain"`
-	// DomainSoftRateLimitThreshold represents the threshold where soft limit window started.
-	DomainSoftRateLimitThreshold uint32 `mapstructure:"domain_soft_limit_threshold"`
 	// TenantIDHeaderName defines tenant HTTP header name. Default x-tenant-id.
 	TenantIDHeaderName string `mapstructure:"tenant_id_header_name"`
 	// Timeout in millis for grpc call.

--- a/processors/ratelimiter/config_test.go
+++ b/processors/ratelimiter/config_test.go
@@ -26,6 +26,5 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, "app", tIDcfg.Domain)
 	assert.Equal(t, "localhost", tIDcfg.ServiceHost)
 	assert.Equal(t, uint16(8081), tIDcfg.ServicePort)
-	assert.Equal(t, uint32(10), tIDcfg.DomainSoftRateLimitThreshold)
 	assert.Equal(t, uint32(10), tIDcfg.TimeoutMillis)
 }

--- a/processors/ratelimiter/factory.go
+++ b/processors/ratelimiter/factory.go
@@ -16,13 +16,12 @@ import (
 )
 
 const (
-	typeStr                         = "hypertrace_ratelimiter"
-	defaultServiceHost              = "127.0.0.1"
-	defaultServicePort              = uint16(8081)
-	defaultDomain                   = "collector"
-	defaultDomainSoftLimitThreshold = uint32(100000) // Soft limit kicks in when limit remaining under 100k
-	defaultHeaderName               = "x-tenant-id"
-	defaultTimeoutMillis            = uint32(1000) // 1 second
+	typeStr              = "hypertrace_ratelimiter"
+	defaultServiceHost   = "127.0.0.1"
+	defaultServicePort   = uint16(8081)
+	defaultDomain        = "collector"
+	defaultHeaderName    = "x-tenant-id"
+	defaultTimeoutMillis = uint32(1000) // 1 second
 )
 
 // NewFactory creates a factory for the ratelimit processor.
@@ -39,12 +38,11 @@ func createDefaultConfig() config.Processor {
 		ProcessorSettings: config.NewProcessorSettings(
 			config.NewComponentID(typeStr),
 		),
-		ServiceHost:                  defaultServiceHost,
-		ServicePort:                  defaultServicePort,
-		Domain:                       defaultDomain,
-		DomainSoftRateLimitThreshold: defaultDomainSoftLimitThreshold,
-		TenantIDHeaderName:           defaultHeaderName,
-		TimeoutMillis:                defaultTimeoutMillis,
+		ServiceHost:        defaultServiceHost,
+		ServicePort:        defaultServicePort,
+		Domain:             defaultDomain,
+		TenantIDHeaderName: defaultHeaderName,
+		TimeoutMillis:      defaultTimeoutMillis,
 	}
 }
 
@@ -63,7 +61,6 @@ func createTraceProcessor(
 	processor := &processor{
 		rateLimitServiceClient:     rateLimitServiceClient,
 		domain:                     pCfg.Domain,
-		domainSoftLimitThreshold:   pCfg.DomainSoftRateLimitThreshold,
 		logger:                     params.Logger,
 		tenantIDHeaderName:         pCfg.TenantIDHeaderName,
 		nextConsumer:               nextConsumer,

--- a/processors/ratelimiter/factory_test.go
+++ b/processors/ratelimiter/factory_test.go
@@ -11,7 +11,6 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.Equal(t, defaultHeaderName, cfg.TenantIDHeaderName)
 	assert.Equal(t, defaultServiceHost, cfg.ServiceHost)
 	assert.Equal(t, defaultServicePort, cfg.ServicePort)
-	assert.Equal(t, defaultDomainSoftLimitThreshold, cfg.DomainSoftRateLimitThreshold)
 	assert.Equal(t, defaultDomain, cfg.Domain)
 	assert.Equal(t, defaultTimeoutMillis, cfg.TimeoutMillis)
 }

--- a/processors/ratelimiter/metrics.go
+++ b/processors/ratelimiter/metrics.go
@@ -7,22 +7,12 @@ import (
 )
 
 var (
-	tagTenantID               = tag.MustNewKey("tenant-id")
-	droppedSpanCountSoftLimit = stats.Int64("tenant_id_dropped_span_count_soft_limit",
-		"Number of spans dropped because of rate limiting per tenant due to soft limit", stats.UnitDimensionless)
-	droppedSpanCount = stats.Int64("tenant_id_dropped_span_count", "Number of spans dropped per tenant due to global rate limiting", stats.UnitDimensionless)
+	tagTenantID      = tag.MustNewKey("tenant-id")
+	droppedSpanCount = stats.Int64("tenant_id_dropped_span_count", "Number of spans dropped per tenant due to rate limiting", stats.UnitDimensionless)
 )
 
 func MetricViews() []*view.View {
 	tags := []tag.Key{tagTenantID}
-
-	viewDroppedSpanCountSoftLimit := &view.View{
-		Name:        droppedSpanCountSoftLimit.Name(),
-		Description: droppedSpanCountSoftLimit.Description(),
-		Measure:     droppedSpanCountSoftLimit,
-		Aggregation: view.Sum(),
-		TagKeys:     tags,
-	}
 
 	viewDroppedSpanCount := &view.View{
 		Name:        droppedSpanCount.Name(),
@@ -33,7 +23,6 @@ func MetricViews() []*view.View {
 	}
 
 	return []*view.View{
-		viewDroppedSpanCountSoftLimit,
 		viewDroppedSpanCount,
 	}
 }

--- a/processors/ratelimiter/testdata/config.yml
+++ b/processors/ratelimiter/testdata/config.yml
@@ -7,7 +7,6 @@ processors:
     service_host: localhost
     service_port: 8081
     domain: app
-    domain_soft_limit_threshold: 10
     timeout_millis: 10
 exporters:
   nop:


### PR DESCRIPTION
## Description
Simplified rate limiting by removing soft limit, now there will be only cluster and tenant limit. If both limits crossed then request will be dropped and otherwise request will be forwarded to next consumer. 


##Testing
Updated tests to handle the above scenarios. 