### PR TITLE
Add rate limit service call count metric

### DIFF
--- a/processors/ratelimiter/metrics.go
+++ b/processors/ratelimiter/metrics.go
@@ -7,8 +7,9 @@ import (
 )
 
 var (
-	tagTenantID      = tag.MustNewKey("tenant-id")
-	droppedSpanCount = stats.Int64("tenant_id_dropped_span_count", "Number of spans dropped per tenant due to rate limiting", stats.UnitDimensionless)
+	tagTenantID                = tag.MustNewKey("tenant-id")
+	droppedSpanCount           = stats.Int64("tenant_id_dropped_span_count", "Number of spans dropped per tenant due to rate limiting", stats.UnitDimensionless)
+	rateLimitServiceCallsCount = stats.Int64("tenant_id_rate_limit_service_calls_count", "Number of calls to rate limiter service from collector", stats.UnitDimensionless)
 )
 
 func MetricViews() []*view.View {
@@ -22,7 +23,15 @@ func MetricViews() []*view.View {
 		TagKeys:     tags,
 	}
 
+	viewRateLimitServiceCallsCount := &view.View{
+		Name:        rateLimitServiceCallsCount.Name(),
+		Description: rateLimitServiceCallsCount.Description(),
+		Measure:     rateLimitServiceCallsCount,
+		Aggregation: view.Sum(),
+		TagKeys:     tags,
+	}
+
 	return []*view.View{
-		viewDroppedSpanCount,
+		viewDroppedSpanCount, viewRateLimitServiceCallsCount,
 	}
 }


### PR DESCRIPTION
## Description
Add metrics for call count to rate limit service for each tenant

