### PR TITLE
fix: remove service_name metric label if service.name resource attr exists

### DIFF
--- a/processors/metricresourceattrstoattrs/metricresourcesattrstolabels_test.go
+++ b/processors/metricresourceattrstoattrs/metricresourcesattrstolabels_test.go
@@ -246,7 +246,7 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 			},
 			dt: pmetric.MetricTypeGauge,
 		},
-		"service_instance_id does not attribute exists for gauge metric: service.instance.id resource attr added": {
+		"service_instance_id attribute does not exists for gauge metric: service.instance.id resource attr added": {
 			inputResourceAttributes: map[string]string{
 				conventions.AttributeServiceName:       "test-service",
 				conventions.AttributeServiceInstanceID: "test-instance-id",
@@ -254,6 +254,24 @@ func TestCopyingResourceAttributesToMetricAttributes(t *testing.T) {
 			},
 			inputMetricAttributes: map[string]string{
 				"foo10": "baz10",
+			},
+			expectedMetricAttributes: map[string]string{
+				"foo10":                                "baz10",
+				conventions.AttributeServiceName:       "test-service",
+				conventions.AttributeServiceInstanceID: "test-instance-id",
+				"port":                                 "8888",
+			},
+			dt: pmetric.MetricTypeGauge,
+		},
+		"service.name resource attribute exists. service_name attribute exists for gauge metric: service_name attr removed": {
+			inputResourceAttributes: map[string]string{
+				conventions.AttributeServiceName:       "test-service",
+				conventions.AttributeServiceInstanceID: "test-instance-id",
+				"port":                                 "8888",
+			},
+			inputMetricAttributes: map[string]string{
+				"foo10":              "baz10",
+				ocServiceNameAttrKey: "different-service-name",
 			},
 			expectedMetricAttributes: map[string]string{
 				"foo10":                                "baz10",

--- a/processors/tenantidprocessor/tenantidprocessor_test.go
+++ b/processors/tenantidprocessor/tenantidprocessor_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"testing"
@@ -578,7 +577,7 @@ func sendToJaegerHTTPThrift(endpoint string, headers map[string]string, batch *j
 		return err
 	}
 
-	io.Copy(ioutil.Discard, resp.Body)
+	io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {


### PR DESCRIPTION
## Description
In the most recent otel collector upgrade, `service_name` is now a metric label. So is `service.name` resource attribute which is copied over into the metric labels by the metricresourceattrstoattrs processor. However, prometheus exporter sanitizes `service.name` into `service_name` resulting into 2 labels with the same name, hence it throws an error about duplicate label names. This is an issue that was previously fixed for `service_instance_id`.

### Testing
Unit tests and local testing.

### Checklist:
- [✅  ] My changes generate no new warnings
- [ ✅ ] I have added tests that prove my fix is effective or that my feature works
- [✅  ] Any dependent changes have been merged and published in downstream modules
