### PR TITLE
chore: use trivy image scan and ubuntu latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,4 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: hypertrace/github-actions/trivy-image-scan@main
         with:
-          image: hypertrace/hypertrace-collector:latest
+          image: hypertrace/hypertrace-collector

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,4 @@ jobs:
         uses: hypertrace/github-actions/trivy-image-scan@main
         with:
           image: hypertrace/hypertrace-collector
+          tag: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,7 @@ jobs:
           build-args: |
             VERSION=latest
             GIT_COMMIT=${GITHUB_SHA}
-      - name: Scan docker image
-        uses: azure/container-scan@v0.1
+      - name: Run Trivy vulnerability scanner
+        uses: hypertrace/github-actions/trivy-image-scan@main
         with:
-          image-name: hypertrace/hypertrace-collector:latest
-        env:
-          DOCKLE_HOST: "unix:///var/run/docker.sock"
-        continue-on-error: true
+          image: hypertrace/hypertrace-collector:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish-artifacts:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
       - name: Check out code
@@ -38,7 +38,7 @@ jobs:
 
   publish-helm-charts:
     needs: publish-artifacts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
       - name: Checkout Repository

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   static-analysis:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description
Use hypertrace/github-actions/trivy-image-scan@main for container scanning and standardize build image to ubuntu-latest

