### PR TITLE
fix: filter more automatically created otel metrics

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -201,12 +201,16 @@ configMap:
           exclude:
             match_type: regexp
             metric_names:
-              - http\.server\.duration.*
-              - rpc\.server\.duration.*
-              - http\.server\.request_content_length
-              - http\.server\.response_content_length
-              - http\.client\.duration.*
-
+              - ^http\.server.*
+              - ^http\.client.*
+              - ^rpc\.server.*
+              - ^rpc\.client.*
+              - .*db.*
+              - .*jvm.*
+              - .*kafka.*
+              - processedSpans
+              - queueSize
+              - ^otlp.*
     exporters:
       kafka:
         protocol_version: 2.0.0


### PR DESCRIPTION
## Description
These are created by otel based agents. We had to enhance this since the java based otel agent creates a lot of metrics automatically. It captures the jmx metrics as well. These lead to high memory consumption and an eventual OOM crash in k8s based systems.

### Testing
Manual tests.

### Checklist:
- [✅  ] My changes generate no new warnings
- [✅  ] Any dependent changes have been merged and published in downstream modules
