### PR TITLE
fix: use bullseye image instead of bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-bookworm as build-stage
+FROM golang:1.20-bullseye as build-stage
 
 RUN mkdir -p /go/src/github.com/hypertrace/collector
 WORKDIR /go/src/github.com/hypertrace/collector


### PR DESCRIPTION
## Description
Since golang bookworm base image has GLIBC version issues, we will use the bullseye image. They are both still being maintained unlike buster. Error:
```
[tim.mwangi@saas-dev-bastion ~]$ kubectl logs hypertrace-collector-6965fccf6c-2kvwh -n traceable
/usr/local/bin/hypertrace/collector: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /usr/local/bin/hypertrace/collector)
/usr/local/bin/hypertrace/collector: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /usr/local/bin/hypertrace/collector)
```

### Testing
Build and test the image locally.

### Checklist:
- [ ✅ ] My changes generate no new warnings
- [✅  ] Any dependent changes have been merged and published in downstream modules
