### PR TITLE
feat: upgrade to go 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   test-and-build:
     strategy:
       matrix:
-        go-version: ["1.21"]
+        go-version: ["1.22"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'go' ]
-        go-version: ["1.21"]
+        go-version: ["1.22"]
 
     steps:
       - name: Checkout repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-bullseye as build-stage
+FROM golang:1.22-bullseye as build-stage
 
 RUN mkdir -p /go/src/github.com/hypertrace/collector
 WORKDIR /go/src/github.com/hypertrace/collector

--- a/exporter/kafkaexporter/go.mod
+++ b/exporter/kafkaexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
 
-go 1.21.0
+go 1.22
 
 require (
 	github.com/IBM/sarama v1.43.2

--- a/exporter/prometheusexporter/go.mod
+++ b/exporter/prometheusexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter
 
-go 1.21.0
+go 1.22
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.102.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/hypertrace/collector
 
-go 1.21.0
-
-toolchain go1.22.1
+go 1.22
 
 require (
 	github.com/apache/thrift v0.20.0

--- a/receiver/jaegerreceiver/go.mod
+++ b/receiver/jaegerreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
 
-go 1.21.0
+go 1.22
 
 require (
 	github.com/apache/thrift v0.20.0


### PR DESCRIPTION
In order to fix a vulnerability we have upgraded the latest go 1.22

```
hypertrace/hypertrace-collector:latest (debian 12.7)
====================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


usr/local/bin/hypertrace/collector (gobinary)
=============================================
Total: 1 (HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬───────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                           Title                           │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼───────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-34156 │ HIGH     │ fixed  │ 1.21.13           │ 1.22.7, 1.23.1 │ encoding/gob: golang: Calling Decoder.Decode on a message │
│         │                │          │        │                   │                │ which contains deeply nested structures...                │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2024-34156                │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴───────────────────────────────────────────────────────────┘
```

### Testing
Building and running locally

### Checklist:
- [✅  ] My changes generate no new warnings
