### PR TITLE
fix: use 0.0.0.0:13133 for the health check endpoint

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -269,7 +269,8 @@ configMap:
   name: hypertrace-collector-config
   data:
     extensions:
-      health_check: {}
+      health_check:
+        endpoint: 0.0.0.0:13133
       pprof:
         endpoint: 0.0.0.0:1777
       zpages:


### PR DESCRIPTION
## Description
It is now defaulting to starting on localhost:13133 and this does not work for k8s health checks.

